### PR TITLE
use item: if possible

### DIFF
--- a/agents/llm_agents/samples/llm/interview.ts
+++ b/agents/llm_agents/samples/llm/interview.ts
@@ -109,7 +109,7 @@ export const graph_data = {
                 person0: "person1",
               },
             },
-            inputs: { array: [":context"] },
+            inputs: { item: ":context" },
           },
           swappedMessages: {
             // Swaps the user and assistant of messages

--- a/agents/llm_agents/samples/llm/interview_jp.ts
+++ b/agents/llm_agents/samples/llm/interview_jp.ts
@@ -116,7 +116,7 @@ export const graph_data = {
                 person0: "person1",
               },
             },
-            inputs: { array: [":context"] },
+            inputs: { item: ":context" },
             isResult: true,
           },
           swappedMessages: {

--- a/agents/llm_agents/samples/llm/interview_ollama.ts
+++ b/agents/llm_agents/samples/llm/interview_ollama.ts
@@ -102,7 +102,7 @@ export const graph_data = {
                 person0: "person1",
               },
             },
-            inputs: { array: [":context"] },
+            inputs: { item: ":context" },
           },
           swappedMessages: {
             agent: "propertyFilterAgent",

--- a/agents/llm_agents/samples/llm/interview_phi3.ts
+++ b/agents/llm_agents/samples/llm/interview_phi3.ts
@@ -102,7 +102,7 @@ export const graph_data = {
                 person0: "person1",
               },
             },
-            inputs: { array: [":context"] },
+            inputs: { item: ":context" },
           },
           swappedMessages: {
             agent: "propertyFilterAgent",


### PR DESCRIPTION
Use a simpler "item" property instead of "array" property (for propertyFilterAgent), if it is possible (no "inject" or "inspect").