### PR TITLE
Fix TypeScript compilation error in test_graph.ts

### DIFF
--- a/agents/agent_utils/tests/test_graph.ts
+++ b/agents/agent_utils/tests/test_graph.ts
@@ -1,6 +1,6 @@
 import * as vanilla_agent from "@graphai/vanilla";
 
-import { GraphAI } from "graphai";
+import { GraphAI, AgentFunctionInfo } from "graphai";
 
 import { sample2GraphData } from "@/index";
 
@@ -8,7 +8,7 @@ import test from "node:test";
 import assert from "node:assert";
 
 test("test graph", async () => {
-  for await (const agent of Object.values(vanilla_agent)) {
+  for await (const agent of Object.values<AgentFunctionInfo>(vanilla_agent)) {
     if (agent.samples && agent.name !== "workerAgent" && agent.name !== "mergeNodeIdAgent") {
       await Promise.all(
         agent.samples.map(async (sample) => {


### PR DESCRIPTION
This pull request resolves the "Parameter 'sample' implicitly has an 'any' type" error in
agents/agent_utils/tests/test_graph.ts. The error appeared when running the command:
```bash
$ yarn workspace @graphai/agent_utils test
```

```jsstacktrace
yarn workspace v1.22.22
yarn run v1.22.22
$ node --test  -r tsconfig-paths/register --require ts-node/register ./tests/test_*.ts
TAP version 13
# /home/ike/workspace/graph-ai/graphai/node_modules/ts-node/src/index.ts:859
#     return new TSError(diagnosticText, diagnosticCodes, diagnostics);
#            ^
# TSError: ⨯ Unable to compile TypeScript:
# tests/test_graph.ts(14,34): error TS7006: Parameter 'sample' implicitly has an 'any' type.
#     at createTSError (/home/ike/workspace/graph-ai/graphai/node_modules/ts-node/src/index.ts:859:12)
#     at reportTSError (/home/ike/workspace/graph-ai/graphai/node_modules/ts-node/src/index.ts:863:19)
#     at getOutput (/home/ike/workspace/graph-ai/graphai/node_modules/ts-node/src/index.ts:1077:36)
#     at Object.compile (/home/ike/workspace/graph-ai/graphai/node_modules/ts-node/src/index.ts:1433:41)
#     at Module.m._compile (/home/ike/workspace/graph-ai/graphai/node_modules/ts-node/src/index.ts:1617:30)
#     at node:internal/modules/cjs/loader:1708:10
#     at Object.require.extensions.<computed> [as .ts] (/home/ike/workspace/graph-ai/graphai/node_modules/ts-node/src/index.ts:1621:12)
#     at Module.load (node:internal/modules/cjs/loader:1318:32)
#     at Function._load (node:internal/modules/cjs/loader:1128:12)
#     at TracingChannel.traceSync (node:diagnostics_channel:322:14) {
#   diagnosticCodes: [ 7006 ]
# }
# Subtest: tests/test_graph.ts
not ok 1 - tests/test_graph.ts
  ---
  duration_ms: 620.670743
  location: '/home/ike/workspace/graph-ai/graphai/agents/agent_utils/tests/test_graph.ts:1:1'
  failureType: 'testCodeFailure'
  exitCode: 1
  signal: ~
  error: 'test failed'
  code: 'ERR_TEST_FAILURE'
  ...
```

Environments:

- Node.js: 22.12.0
- yarn: 1.22.22



