### PR TITLE
Remove temperature parameter for OpenAI reasoning models

### DIFF
--- a/llm_agents/openai_agent/src/openai_agent.ts
+++ b/llm_agents/openai_agent/src/openai_agent.ts
@@ -132,7 +132,8 @@ export const openAIAgent: AgentFunction<OpenAIParams, OpenAIResult, OpenAIInputs
     tools,
     tool_choice,
     max_tokens,
-    temperature: temperature ?? 0.7,
+    // Reasoning models do not support temperature parameter
+    ...(model && (model.startsWith('o1') || model.startsWith('o3')) ? {} : { temperature: temperature ?? 0.7 }),
     response_format,
   };
 


### PR DESCRIPTION
When making calls to OpenAI reasoning models (`o1`, `o3`, etc.), including the temperature parameter in the API call will cause the following error: 

```
Error: BadRequestError: 400 Unsupported parameter: 'temperature' is not supported with this model.
    at _APIError.generate (@graphai_openai_agent.js?v=d74c3aee:782:18)
    at OpenAI.makeStatusError (@graphai_openai_agent.js?v=d74c3aee:1685:33)
    at OpenAI.makeRequest (@graphai_openai_agent.js?v=d74c3aee:1729:28)
    at async _ChatCompletionStream._createChatCompletion (@graphai_openai_agent.js?v=d74c3aee:3806:24)
    at async _ChatCompletionStream._runChatCompletion (@graphai_openai_agent.js?v=d74c3aee:3254:16)
 ```
 
 This PR checks if the model is one of these models, and if so, will not include `temperature` in the `ChatParams`
 