### PR TITLE
update In-memory RAG sample to fix tokenBoundStringsAgent issue

### DIFF
--- a/docs/Tutorial.md
+++ b/docs/Tutorial.md
@@ -421,6 +421,8 @@ nodes:
     agent: stringSplitterAgent
     inputs:
       text: :wikipedia.content
+    params:
+      chunkSize: 200
   chunkEmbeddings:
     console:
       before: ...fetching embeddings for chunks
@@ -443,25 +445,27 @@ nodes:
     inputs:
       array: :chunks.contents
       values: :similarities
-  referenceText:
-    agent: tokenBoundStringsAgent
-    inputs:
-      chunks: :sortedChunks
     params:
-      limit: 5000
+      limit: 5  # 上位5件のチャンクだけを取得
+  # 最も関連性の高いチャンクを取得
+  bestChunk:
+    agent: copyAgent
+    inputs:
+      text: :sortedChunks.$0
   prompt:
     agent: stringTemplateAgent
     inputs:
       prompt: :source.query
-      text: :referenceText.content
+      text: :bestChunk.text
     params:
       template: |-
-        Using the following document, ${text}
-
+        Using the following document:
+        ${text}
         ${prompt}
   RagQuery:
     console:
       before: ...performing the RAG query
+      after: true
     agent: openAIAgent
     inputs:
       prompt: :prompt


### PR DESCRIPTION
# Fix: RAG Sample Implementation Results

## Summary
This PR fixes an implementation issue in the RAG (Retrieval-Augmented Generation) sample where the `tokenBoundStringsAgent` was not available. The solution implements an alternative approach using available agents (`copyAgent` with `sortByValuesAgent` and appropriate chunk size settings) to achieve similar functionality. Test results confirm the fix works as expected, with the RAG query returning accurate information about Sam Bankman-Fried's court sentence while the one-shot query returns outdated information.

## Issue Description and Fix Objectives

Implement a RAG (Retrieval-Augmented Generation) pipeline to generate more accurate and up-to-date answers based on information retrieved from external data sources (Wikipedia). Specifically:

- Retrieve information about a specific person (Sam Bankman-Fried) from Wikipedia
- Divide that information into appropriate chunks
- Search for information related to the question (final court judgment)
- Use the relevant information to generate an answer with an LLM
- Compare the answers with and without using RAG

## Ideal Implementation Method

1. Retrieve an article from Wikipedia
2. Divide the article into chunks of appropriate size
3. Calculate vector embeddings for each chunk and the question
4. Identify highly relevant chunks through similarity calculation
5. Limit the highly relevant chunks to an appropriate length (within token count limits)
6. Incorporate the limited chunks into the prompt
7. Generate an answer using the LLM

## Identified Issues in Original Implementation

The original YAML file (`07_in_memory_rag.yaml`) had the following issues:

- It used an agent called `tokenBoundStringsAgent`, but this agent is not available
  ```yaml
  referenceText:
    agent: tokenBoundStringsAgent  # This agent is not available
    inputs:
      chunks: :sortedChunks
    params:
      limit: 5000
  ```
- Error message: `Invalid Agent : tokenBoundStringsAgent is not in AgentFunctionInfoDictionary.`
- This agent was intended to combine multiple chunks and fit them within the specified token count limit

## Implemented Fix

The problem was solved through the following steps:

1. Checked the list of available agents (using the `graphai -l` command)
2. First tried `joinAgent`, but it was also not available
3. Then tried `arrayJoinAgent`, but the output was `[object Object]` and did not work as expected
4. Finally, implemented an alternative solution as follows:
   - Set the chunk size to 200 to generate appropriate-sized chunks
   - Set the limit parameter of `sortByValuesAgent` to 5 to get only the top 5 chunks
   - Used `copyAgent` to get only the most relevant chunk (`sortedChunks.$0`)
   - Incorporated the retrieved chunk into the prompt

## Key Changes in Implementation

Major changes in the modified YAML file (`07_in_memory_rag_fixed.yaml`):

```yaml
# Added chunk size setting
chunks:
  agent: stringSplitterAgent
  inputs:
    text: :wikipedia.content
  params:
    chunkSize: 200  # Set to an appropriate size

# Set to retrieve only the top 5 chunks
sortedChunks:
  agent: sortByValuesAgent
  inputs:
    array: :chunks.contents
    values: :similarities
  params:
    limit: 5  # Limited to top 5

# Used copyAgent instead of tokenBoundStringsAgent
bestChunk:
  agent: copyAgent
  inputs:
    text: :sortedChunks.$0  # Use only the most relevant chunk

# Modified prompt template
prompt:
  agent: stringTemplateAgent
  inputs:
    prompt: :source.query
    text: :bestChunk.text  # Use the retrieved chunk
```

## Complete Fixed YAML File

```yaml
version: 0.5
nodes:
  source:
    value:
      name: Sam Bankman-Fried
      topic: sentence by the court
      query: describe the final sentence by the court for Sam Bank-Fried
  wikipedia:
    console:
      before: ...fetching data from wikkpedia
    agent: wikipediaAgent
    inputs:
      query: :source.name
    params:
      lang: en
  chunks:
    console:
      before: ...splitting the article into chunks
    agent: stringSplitterAgent
    inputs:
      text: :wikipedia.content
    params:
      chunkSize: 200
  chunkEmbeddings:
    console:
      before: ...fetching embeddings for chunks
    agent: stringEmbeddingsAgent
    inputs:
      array: :chunks.contents
  topicEmbedding:
    console:
      before: ...fetching embedding for the topic
    agent: stringEmbeddingsAgent
    inputs:
      item: :source.topic
  similarities:
    agent: dotProductAgent
    inputs:
      matrix: :chunkEmbeddings
      vector: :topicEmbedding.$0
  sortedChunks:
    agent: sortByValuesAgent
    inputs:
      array: :chunks.contents
      values: :similarities
    params:
      limit: 5  # Get only the top 5 chunks
  # Get the most relevant chunk
  bestChunk:
    agent: copyAgent
    inputs:
      text: :sortedChunks.$0
  prompt:
    agent: stringTemplateAgent
    inputs:
      prompt: :source.query
      text: :bestChunk.text
    params:
      template: |-
        Using the following document:
        
        ${text}
        
        ${prompt}
  RagQuery:
    console:
      before: ...performing the RAG query
      after: true
    agent: openAIAgent
    inputs:
      prompt: :prompt
    params:
      model: gpt-4o
  OneShotQuery:
    agent: openAIAgent
    inputs:
      prompt: :source.query
    params:
      model: gpt-4o
  RagResult:
    agent: copyAgent
    inputs:
      result: :RagQuery.text
    isResult: true
  OneShotResult:
    agent: copyAgent
    inputs:
      result: :OneShotQuery.text
    isResult: true
```

## Execution Results

```
...fetching data from wikkpedia
...fetching embedding for the topic
...splitting the article into chunks
...fetching embeddings for chunks
...performing the RAG query
{
  "RagResult": {
    "result": "The court sentenced Sam Bankman-Fried to 25 years in prison."
  },
  "OneShotResult": {
    "result": "As of my last update in October 2023, Sam Bankman-Fried, the former CEO of FTX, was facing legal proceedings related to the collapse of the cryptocurrency exchange. However, there was no final court sentence available at that time. For the most current information, you would need to check the latest news sources or court records."
  }
}
```