### PR TITLE
add tests for cycle detection validation

### DIFF
--- a/packages/graphai/tests/validators/test_validator_inputs.ts
+++ b/packages/graphai/tests/validators/test_validator_inputs.ts
@@ -19,23 +19,6 @@ test("test computed node validation value", async () => {
   await rejectTest(__dirname, graph_data, "Inputs not match: NodeId computed2, Inputs: dummy");
 });
 
-test("test computed node validation value", async () => {
-  const graph_data = anonymization({
-    version: graphDataLatestVersion,
-    nodes: {
-      computed1: {
-        agent: "echoAgent",
-        inputs: [":computed2"],
-      },
-      computed2: {
-        agent: "echoAgent",
-        inputs: [":computed1"],
-      },
-    },
-  });
-  await rejectTest(__dirname, graph_data, "No Initial Runnning Node");
-});
-
 test("test no initial running node", async () => {
   const graph_data = anonymization({
     version: graphDataLatestVersion,
@@ -71,4 +54,55 @@ test("test closed loop validation", async () => {
     },
   });
   await rejectTest(__dirname, graph_data, "Some nodes are not executed: computed3");
+});
+
+test("test cycle detection validation: starts with static node", async () => {
+  const graphData = anonymization({
+    version: graphDataLatestVersion,
+    nodes: {
+      staticNode1: {
+        value: "static value 1",
+      },
+      computedNode1: {
+        agent: "echoAgent",
+        inputs: [":staticNode1", ":computedNode3"],
+      },
+      computedNode2: {
+        agent: "echoAgent",
+        inputs: [":computedNode1"],
+      },
+      computedNode3: {
+        agent: "echoAgent",
+        inputs: [":computedNode2"],
+      },
+    },
+  });
+  // ToDo: More friendly message to tell user cycle detected
+  await rejectTest(__dirname, graphData, "No Initial Runnning Node");
+});
+
+test("test cycle detection validation: starts with computed node", async () => {
+  const graphData = anonymization({
+    version: graphDataLatestVersion,
+    nodes: {
+      computedNode1: {
+        agent: "echoAgent",
+        inputs: {},
+      },
+      computedNode2: {
+        agent: "echoAgent",
+        inputs: { array: [":computedNode1", ":computedNode4"] },
+      },
+      computedNode3: {
+        agent: "echoAgent",
+        inputs: { array: [":computedNode2"] },
+      },
+      computedNode4: {
+        agent: "echoAgent",
+        inputs: { array: [":computedNode3"] },
+      },
+    },
+  });
+  // ToDo: More friendly message to tell user cycle detected
+  await rejectTest(__dirname, graphData, "Some nodes are not executed: computedNode2, computedNode3, computedNode4");
 });

--- a/packages/graphai/tests/validators/test_validator_named_inputs.ts
+++ b/packages/graphai/tests/validators/test_validator_named_inputs.ts
@@ -19,23 +19,6 @@ test("test computed node validation value", async () => {
   await rejectTest(__dirname, graph_data, "Inputs not match: NodeId computed2, Inputs: dummy");
 });
 
-test("test computed node validation value", async () => {
-  const graph_data = anonymization({
-    version: graphDataLatestVersion,
-    nodes: {
-      computed1: {
-        agent: "echoAgent",
-        inputs: { text: ":computed2" },
-      },
-      computed2: {
-        agent: "echoAgent",
-        inputs: { text: ":computed1" },
-      },
-    },
-  });
-  await rejectTest(__dirname, graph_data, "No Initial Runnning Node");
-});
-
 test("test no initial running node", async () => {
   const graph_data = anonymization({
     version: graphDataLatestVersion,
@@ -151,4 +134,69 @@ test("test closed loop validation nested named Inputs", async () => {
     },
   });
   await rejectTest(__dirname, graph_data, "If not match: NodeId computed3, Inputs: computed4");
+});
+
+test("test cycle detection validation: starts with static node", async () => {
+  const graphData = anonymization({
+    version: graphDataLatestVersion,
+    nodes: {
+      staticNode1: {
+        value: "static value 1",
+      },
+      computedNode1: {
+        agent: "echoAgent",
+        inputs: {
+          text1: ":staticNode1",
+          text2: ":computedNode3",
+        },
+      },
+      computedNode2: {
+        agent: "echoAgent",
+        inputs: {
+          text: ":computedNode1",
+        },
+      },
+      computedNode3: {
+        agent: "echoAgent",
+        inputs: {
+          text: ":computedNode2",
+        },
+      },
+    },
+  });
+  // ToDo: More friendly message to tell user cycle detected
+  await rejectTest(__dirname, graphData, "No Initial Runnning Node");
+});
+
+test("test cycle detection validation: starts with computed node", async () => {
+  const graphData = anonymization({
+    version: graphDataLatestVersion,
+    nodes: {
+      computedNode1: {
+        agent: "echoAgent",
+        inputs: [],
+      },
+      computedNode2: {
+        agent: "echoAgent",
+        inputs: {
+          message1: ":computedNode1",
+          message2: ":computedNode4",
+        },
+      },
+      computedNode3: {
+        agent: "echoAgent",
+        inputs: {
+          message1: ":computedNode2",
+        },
+      },
+      computedNode4: {
+        agent: "echoAgent",
+        inputs: {
+          message2: ":computedNode3",
+        },
+      },
+    },
+  });
+  // ToDo: More friendly message to tell user cycle detected
+  await rejectTest(__dirname, graphData, "Some nodes are not executed: computedNode2, computedNode3, computedNode4");
 });


### PR DESCRIPTION
fix: #925

## Summary
This PR adds cycle detection validation tests for GraphAI validator. 
Additinally, cleaned up duplicated tests.

## Next Steps
Improve error messages to explicitly indicate cycle detection rather than using generic validation errors.