### PR TITLE
Fixed the problem, embedding's sample does not work because of tokenBoundStringsAgent.

### DIFF
--- a/packages/samples/src/embeddings/wikipedia.ts
+++ b/packages/samples/src/embeddings/wikipedia.ts
@@ -3,6 +3,7 @@ import { graphDataTestRunner } from "@receptron/test_utils";
 import * as llm_agents from "@graphai/llm_agents";
 import * as service_agents from "@graphai/service_agents";
 import * as vanilla from "@graphai/vanilla";
+import { tokenBoundStringsAgent } from "@graphai/token_bound_string_agent";
 
 export const graph_data = {
   version: 0.5,
@@ -106,7 +107,7 @@ export const main = async () => {
     __dirname + "/../",
     "sample_wiki.log",
     graph_data,
-    { ...service_agents, ...vanilla, ...llm_agents },
+    { ...service_agents, ...vanilla, ...llm_agents, tokenBoundStringsAgent },
     () => {},
     false,
   );


### PR DESCRIPTION
## Summary

The embeddings sample(packages/samples/src/embeddings/wikipedia.ts) did not work well. So I fixed it temporarily.

## Description

The error happened because tokenBoundStringsAgent is not in  AgentFunctionInfoDictionary when I run it.
```bash
$ npx ts-node  -r tsconfig-paths/register ./src/embeddings/wikipedia.ts
/Users/d.abe/works/graphai/packages/graphai/src/validators/agent_validator.ts:7
      throw new ValidationError("Invalid Agent : " + agentId + " is not in AgentFunctionInfoDictionary.");
            ^
F [Error]: Invalid Agent : tokenBoundStringsAgent is not in AgentFunctionInfoDictionary.
```

The Places I modified are only the following 2 lines.
1. import tokenBoundStringsAgent
2. makes it enable for graphDataTestRunner.