### PR TITLE
Improved error handling mainly for cases where inputs are written inc…

### DIFF
--- a/packages/graphai/src/utils/nodeUtils.ts
+++ b/packages/graphai/src/utils/nodeUtils.ts
@@ -22,5 +22,8 @@ export const inputs2dataSources = (inputs: any): DataSource[] => {
 };
 
 export const dataSourceNodeIds = (sources: DataSource[]): string[] => {
+  if (!Array.isArray(sources)) {
+    throw new Error("sources must be array!! maybe inputs is invalid");
+  };
   return sources.filter((source: DataSource) => source.nodeId).map((source) => source.nodeId!);
 };

--- a/packages/graphai/tests/units/test_error.ts
+++ b/packages/graphai/tests/units/test_error.ts
@@ -1,0 +1,63 @@
+import { GraphAI } from "@/index";
+
+import * as agents from "~/test_agents";
+
+import { graphDataLatestVersion } from "~/common";
+import { anonymization, rejectTest } from "@receptron/test_utils";
+
+import test from "node:test";
+import assert from "node:assert";
+
+test("test throw error", async () => {
+  const graph_data = {
+    version: graphDataLatestVersion,
+    nodes: {
+      echo: {
+        agent: "echoAgent",
+        params: {
+          message: "hello",
+        },
+      },
+      errorNode: {
+        agent: async (__namedInputs: { text: string }) => {
+          throw new Error("hello");
+        },
+      inputs: { text: ":echo.message" },
+      },
+    },
+  };
+
+  const graph = new GraphAI(graph_data, { ...agents });
+  try {
+    await graph.run();
+  } catch (__error) {
+    // nothing
+  }
+  assert.equal(graph.nodes.errorNode.state, "failed");
+});
+
+test("test throw error", async () => {
+  const graph_data = anonymization({
+    version: graphDataLatestVersion,
+    nodes: {
+      echo: {
+        agent: "echoAgent",
+        params: {
+          message: "hello",
+        },
+      },
+      invalidInput: {
+        agent: "copyAgent",
+        inputs: "123",
+      },
+    },
+  });
+
+  await assert.rejects(
+    async () => {
+      const graph = new GraphAI(graph_data, { ...agents });
+      await graph.run();
+    },
+    { name: "Error", message: "sources must be array!! maybe inputs is invalid" },
+  );
+});

--- a/packages/graphai/tests/units/test_error.ts
+++ b/packages/graphai/tests/units/test_error.ts
@@ -3,7 +3,7 @@ import { GraphAI } from "@/index";
 import * as agents from "~/test_agents";
 
 import { graphDataLatestVersion } from "~/common";
-import { anonymization, rejectTest } from "@receptron/test_utils";
+import { anonymization } from "@receptron/test_utils";
 
 import test from "node:test";
 import assert from "node:assert";


### PR DESCRIPTION
```
aaaAgent:
  inputs: :aaa
  agent: copyAgent
```
then
```
error TypeError: t.filter is not a function
```  

This error was changed because the cause was difficult to understand.

```
sources must be array!! maybe inputs is invalid
```