### PR TITLE
Fix: Resolve TS7006 error in agent_utils test by adding type any

### DIFF
--- a/agents/agent_utils/tests/test_graph.ts
+++ b/agents/agent_utils/tests/test_graph.ts
@@ -11,7 +11,7 @@ test("test graph", async () => {
   for await (const agent of Object.values(vanilla_agent)) {
     if (agent.samples && agent.name !== "workerAgent" && agent.name !== "mergeNodeIdAgent") {
       await Promise.all(
-        agent.samples.map(async (sample) => {
+        agent.samples.map(async (sample: any) => {
           const graphData = sample2GraphData(sample, agent.name);
           // console.log( JSON.stringify(graphData, null, 2));
           const graph = new GraphAI(graphData, vanilla_agent);


### PR DESCRIPTION
This PR fixes a TypeScript compilation error (TS7006: Parameter 'sample' implicitly has an 'any' type) that occurred in agents/agent_utils/tests/test_graph.ts when running yarn run test.

**Problem:**
The sample parameter in the map callback function lacked an explicit type annotation, causing the TypeScript compiler to fail due to the noImplicitAny (or strict) setting being enabled.

> Running `yarn run test` caused a TypeScript compilation error:
> `TS7006: Parameter 'sample' implicitly has an 'any' type.`
> in `agents/agent_utils/tests/test_graph.ts`.

**Solution:**
Added an explicit : any type annotation to the sample parameter on line 15 (approximately) of tests/test_graph.ts. This allows the test suite for @graphai/agent_utils to compile and run successfully.

**Note:**
Using any resolves the immediate compilation issue. A more specific type or interface could be defined for sample in the future for improved type safety, but this change ensures the tests pass for now.