### PR TITLE
Fix typo in `APIDocument.md`: "Dictonary" -> "Dictionary"

### DIFF
--- a/APIDocument.md
+++ b/APIDocument.md
@@ -1,17 +1,17 @@
 ## GraphAI class
 
-### ```constructor(data: GraphData, callbackDictonary: AgentFunctionInfoDictonary)```
+### ```constructor(data: GraphData, callbackDictionary: AgentFunctionInfoDictionary)```
 Initializes a new instance of the GraphAI object with the specified graph data and a dictionary of callback functions.
 
 - ```data: GraphData```: The graph data including nodes and optional concurrency limit.
-- ```callbackDictonary: AgentFunctionInfoDictonary```: A dictionary mapping agent IDs to their respective callback functions info to be used for all nodes.
+- ```callbackDictionary: AgentFunctionInfoDictionary```: A dictionary mapping agent IDs to their respective callback functions info to be used for all nodes.
 
-### ```async run(): Promise<ResultDataDictonary<ResultData>>```
+### ```async run(): Promise<ResultDataDictionary<ResultData>>```
 Executes the graph asynchronously, starting with nodes that have no dependencies or whose dependencies have been met. The method continues to execute nodes as their dependencies are satisfied until all nodes have been executed or an error occurs.
 
 Returns: A promise that resolves with the results of all executed nodes or rejects with the first encountered error.
 
-### ```results(): ResultDataDictonary<ResultData>```
+### ```results(): ResultDataDictionary<ResultData>```
 Compiles and returns the results of all executed nodes in the graph.
 
 Returns: A dictionary mapping node IDs to their results. Only includes nodes that have completed execution and produced a result.


### PR DESCRIPTION
SSIA