### PR TITLE
Handle deprecation of array inputs

### DIFF
--- a/docs/NamedInputs.md
+++ b/docs/NamedInputs.md
@@ -1,0 +1,88 @@
+# Named Inputs in GraphAI
+
+GraphAI has moved from array-based inputs to named inputs to improve code readability and maintainability. This document explains the new input format and how to migrate from the old format.
+
+## Old Format (Deprecated)
+
+The old format used array-based inputs:
+
+```yaml
+inputs:
+  - :someNode.output
+  - value: "some static value"
+```
+
+## New Format
+
+The new format uses named inputs:
+
+```yaml
+inputs:
+  data: :someNode.output
+  staticValue: "some static value"
+```
+
+## Migration Guide
+
+### Basic Input
+
+Old format:
+```yaml
+inputs:
+  - :someNode.output
+```
+
+New format:
+```yaml
+inputs:
+  data: :someNode.output
+```
+
+### Multiple Inputs
+
+Old format:
+```yaml
+inputs:
+  - :firstNode.output
+  - :secondNode.output
+```
+
+New format:
+```yaml
+inputs:
+  array: [:firstNode.output, :secondNode.output]
+```
+
+### Static Values
+
+Old format:
+```yaml
+inputs:
+  - role: user
+  - content: "Hello"
+```
+
+New format:
+```yaml
+inputs:
+  role: "user"
+  content: "Hello"
+```
+
+## Example
+
+```yaml
+# Old
+agent: stringTemplateAgent
+params:
+  template: "Hello, ${0}!"
+inputs:
+  - :name.value
+
+# New
+agent: stringTemplateAgent
+params:
+  template: "Hello, ${name}!"
+inputs:
+  name: :name.value
+```

--- a/docs/examples/tutorial/1-hello.yaml
+++ b/docs/examples/tutorial/1-hello.yaml
@@ -11,4 +11,4 @@ nodes:
     console:
       after: true
     inputs:
-      - :llm.choices.$0.message.content
+      contant: ":llm.choices.$0.message.content"

--- a/docs/examples/tutorial/2-loop.yaml
+++ b/docs/examples/tutorial/2-loop.yaml
@@ -16,8 +16,9 @@ nodes:
   prompt:
     agent: stringTemplateAgent
     params:
-      template: What is the typical color of ${0}? Just answer the color.
-    inputs: [:shift.item]
+      template: What is the typical color of ${item}? Just answer the color.
+    inputs:
+      item: :shift.item
   llm:
     agent: openAIAgent
     params:
@@ -27,6 +28,6 @@ nodes:
   reducer:
     agent: pushAgent
     inputs:
-      array: :result
+      array: [:result]
       item: :llm.choices.$0.message.content
 


### PR DESCRIPTION
1. Fixes some example files using array inputs
2. Creates `doc/NamedInputs.md` because there are error messages that mention the markdown: https://github.com/receptron/graphai/blob/831c24afc9eca5454f7e3d8fa4fa569487324931/packages/graphai/src/node.ts#L137