### PR TITLE
Fix `fileFullPath` function to handle absolute paths properly

### DIFF
--- a/packages/cli/src/graphai_cli.ts
+++ b/packages/cli/src/graphai_cli.ts
@@ -16,7 +16,7 @@ import { option } from "./options";
 import { mermaid } from "./mermaid";
 
 const fileFullPath = (file: string) => {
-  return path.resolve(process.cwd() + "/" + file) || "";
+  return path.isAbsolute(file) ? file : path.resolve(process.cwd(), file);
 };
 
 const agents = {


### PR DESCRIPTION
`fileFullPath` function handles relative paths properly but absolute paths. This PR fixes the function to handle the both properly.