### PR TITLE
Remove path alias usage in graphai tests

### DIFF
--- a/packages/graphai/package.json
+++ b/packages/graphai/package.json
@@ -9,13 +9,13 @@
     "./lib"
   ],
   "scripts": {
-    "build": "rm -r lib/* && tsc && npx rollup -c && tsc-alias",
+    "build": "rm -r lib/* && tsc && npx rollup -c",
     "eslint": "eslint",
     "typedoc": "npx typedoc src/index.ts --out ../../docs/apiDoc",
     "typedoc:md": "npx typedoc src/index.ts --out ../../docs/apiDocMd --plugin typedoc-plugin-markdown",
     "doc": "echo nothing",
     "format": "prettier --write '{src,tests,samples}/**/*.ts' *.mjs",
-    "test": "node --test  -r tsconfig-paths/register --require ts-node/register ./tests/**/test_*.ts",
+    "test": "node --test --require ts-node/register ./tests/**/test_*.ts",
     "b": "yarn run format && yarn run eslint && yarn run build"
   },
   "repository": {

--- a/packages/graphai/tests/agentFilters/test_filter_params.ts
+++ b/packages/graphai/tests/agentFilters/test_filter_params.ts
@@ -1,7 +1,7 @@
-import { GraphAI, AgentFilterFunction } from "@/index";
+import { GraphAI, AgentFilterFunction } from "../../src/index";
 
-import * as agents from "~/test_agents";
-import { graphDataLatestVersion } from "~/common";
+import * as agents from "../test_agents";
+import { graphDataLatestVersion } from "../common";
 
 import test from "node:test";
 import assert from "node:assert";

--- a/packages/graphai/tests/agentFilters/test_isResult.ts
+++ b/packages/graphai/tests/agentFilters/test_isResult.ts
@@ -1,8 +1,8 @@
-import { GraphAI } from "@/index";
-import { AgentFilterFunction } from "@/type";
+import { GraphAI } from "../../src/index";
+import { AgentFilterFunction } from "../../src/type";
 
-import * as agents from "~/test_agents";
-import { graphDataLatestVersion } from "~/common";
+import * as agents from "../test_agents";
+import { graphDataLatestVersion } from "../common";
 
 import test from "node:test";
 import assert from "node:assert";

--- a/packages/graphai/tests/agentFilters/test_nested.ts
+++ b/packages/graphai/tests/agentFilters/test_nested.ts
@@ -1,7 +1,7 @@
-import { GraphAI, AgentFilterFunction } from "@/index";
+import { GraphAI, AgentFilterFunction } from "../../src/index";
 
-import * as agents from "~/test_agents";
-import { graphDataLatestVersion } from "~/common";
+import * as agents from "../test_agents";
+import { graphDataLatestVersion } from "../common";
 
 import test from "node:test";
 import assert from "node:assert";

--- a/packages/graphai/tests/agentFilters/test_simple.ts
+++ b/packages/graphai/tests/agentFilters/test_simple.ts
@@ -1,8 +1,8 @@
-import { GraphAI } from "@/index";
-import { AgentFilterFunction } from "@/type";
+import { GraphAI } from "../../src/index";
+import { AgentFilterFunction } from "../../src/type";
 
-import * as agents from "~/test_agents";
-import { graphDataLatestVersion } from "~/common";
+import * as agents from "../test_agents";
+import { graphDataLatestVersion } from "../common";
 
 import test from "node:test";
 import assert from "node:assert";

--- a/packages/graphai/tests/common.ts
+++ b/packages/graphai/tests/common.ts
@@ -1,1 +1,1 @@
-export { graphDataLatestVersion } from "@/index";
+export { graphDataLatestVersion } from "../src/index";

--- a/packages/graphai/tests/props_functions/test_props_function_array.ts
+++ b/packages/graphai/tests/props_functions/test_props_function_array.ts
@@ -1,6 +1,6 @@
-import { parseNodeName } from "@/utils/utils";
-import { propFunctions } from "@/utils/prop_function";
-import { getDataFromSource } from "@/utils/data_source";
+import { parseNodeName } from "../../src/utils/utils";
+import { propFunctions } from "../../src/utils/prop_function";
+import { getDataFromSource } from "../../src/utils/data_source";
 
 import test from "node:test";
 import assert from "node:assert";

--- a/packages/graphai/tests/props_functions/test_props_function_boolean.ts
+++ b/packages/graphai/tests/props_functions/test_props_function_boolean.ts
@@ -1,6 +1,6 @@
-import { parseNodeName } from "@/utils/utils";
-import { propFunctions } from "@/utils/prop_function";
-import { getDataFromSource } from "@/utils/data_source";
+import { parseNodeName } from "../../src/utils/utils";
+import { propFunctions } from "../../src/utils/prop_function";
+import { getDataFromSource } from "../../src/utils/data_source";
 
 import test from "node:test";
 import assert from "node:assert";

--- a/packages/graphai/tests/props_functions/test_props_function_number.ts
+++ b/packages/graphai/tests/props_functions/test_props_function_number.ts
@@ -1,6 +1,6 @@
-import { parseNodeName } from "@/utils/utils";
-import { propFunctions } from "@/utils/prop_function";
-import { getDataFromSource } from "@/utils/data_source";
+import { parseNodeName } from "../../src/utils/utils";
+import { propFunctions } from "../../src/utils/prop_function";
+import { getDataFromSource } from "../../src/utils/data_source";
 
 import test from "node:test";
 import assert from "node:assert";

--- a/packages/graphai/tests/props_functions/test_props_function_object.ts
+++ b/packages/graphai/tests/props_functions/test_props_function_object.ts
@@ -1,6 +1,6 @@
-import { parseNodeName } from "@/utils/utils";
-import { propFunctions } from "@/utils/prop_function";
-import { getDataFromSource } from "@/utils/data_source";
+import { parseNodeName } from "../../src/utils/utils";
+import { propFunctions } from "../../src/utils/prop_function";
+import { getDataFromSource } from "../../src/utils/data_source";
 
 import test from "node:test";
 import assert from "node:assert";

--- a/packages/graphai/tests/props_functions/test_props_function_text.ts
+++ b/packages/graphai/tests/props_functions/test_props_function_text.ts
@@ -1,6 +1,6 @@
-import { parseNodeName } from "@/utils/utils";
-import { propFunctions } from "@/utils/prop_function";
-import { getDataFromSource } from "@/utils/data_source";
+import { parseNodeName } from "../../src/utils/utils";
+import { propFunctions } from "../../src/utils/prop_function";
+import { getDataFromSource } from "../../src/utils/data_source";
 
 import test from "node:test";
 import assert from "node:assert";

--- a/packages/graphai/tests/props_functions/test_props_function_time.ts
+++ b/packages/graphai/tests/props_functions/test_props_function_time.ts
@@ -1,4 +1,4 @@
-import { resultsOf } from "@/utils/result";
+import { resultsOf } from "../../src/utils/result";
 
 import test from "node:test";
 import assert from "node:assert";

--- a/packages/graphai/tests/test_agents/copy_agent.ts
+++ b/packages/graphai/tests/test_agents/copy_agent.ts
@@ -1,4 +1,4 @@
-import { AgentFunction, AgentFunctionInfo } from "@/index";
+import { AgentFunction, AgentFunctionInfo } from "../../src/index";
 
 export const copyAgent: AgentFunction<{ namedKey?: string }> = async ({ params, namedInputs }) => {
   const { namedKey } = params;

--- a/packages/graphai/tests/test_agents/copy_config_agent.ts
+++ b/packages/graphai/tests/test_agents/copy_config_agent.ts
@@ -1,4 +1,4 @@
-import { AgentFunction, AgentFunctionInfo } from "@/index";
+import { AgentFunction, AgentFunctionInfo } from "../../src/index";
 
 export const copyConfigAgent: AgentFunction<{ namedKey?: string }> = async ({ params, config }) => {
   const { namedKey } = params;

--- a/packages/graphai/tests/test_agents/echo_agent.ts
+++ b/packages/graphai/tests/test_agents/echo_agent.ts
@@ -1,4 +1,4 @@
-import { AgentFunction, AgentFunctionInfo } from "@/index";
+import { AgentFunction, AgentFunctionInfo } from "../../src/index";
 
 export const echoAgent: AgentFunction = async ({ params, filterParams }) => {
   if (params.filterParams) {

--- a/packages/graphai/tests/test_agents/lookup_dictionary_agent.ts
+++ b/packages/graphai/tests/test_agents/lookup_dictionary_agent.ts
@@ -1,5 +1,5 @@
-import type { AgentFunction, AgentFunctionInfo, DefaultResultData } from "@/index";
-import { assert } from "@/index";
+import type { AgentFunction, AgentFunctionInfo, DefaultResultData } from "../../src/index";
+import { assert } from "../../src/index";
 import { isNamedInputs } from "@graphai/agent_utils";
 import type { GraphAISupressError } from "@graphai/agent_utils";
 

--- a/packages/graphai/tests/test_agents/map_agent.ts
+++ b/packages/graphai/tests/test_agents/map_agent.ts
@@ -1,4 +1,4 @@
-import { GraphAI, AgentFunction, AgentFunctionInfo, assert, graphDataLatestVersion } from "@/index";
+import { GraphAI, AgentFunction, AgentFunctionInfo, assert, graphDataLatestVersion } from "../../src/index";
 import type { GraphAISupressError } from "@graphai/agent_utils";
 
 export const mapAgent: AgentFunction<

--- a/packages/graphai/tests/test_agents/nested_agent.ts
+++ b/packages/graphai/tests/test_agents/nested_agent.ts
@@ -1,4 +1,4 @@
-import { GraphAI, AgentFunction, AgentFunctionInfo, StaticNodeData, NodeData, assert, graphDataLatestVersion } from "@/index";
+import { GraphAI, AgentFunction, AgentFunctionInfo, StaticNodeData, NodeData, assert, graphDataLatestVersion } from "../../src/index";
 
 export const nestedAgent: AgentFunction<{
   namedInputs?: Array<string>;

--- a/packages/graphai/tests/test_agents/push_agent.ts
+++ b/packages/graphai/tests/test_agents/push_agent.ts
@@ -1,4 +1,4 @@
-import { AgentFunction, AgentFunctionInfo, assert } from "@/index";
+import { AgentFunction, AgentFunctionInfo, assert } from "../../src/index";
 import { arrayValidate } from "@graphai/agent_utils";
 
 export const pushAgent: AgentFunction<null, { array: Array<unknown> }, { array: Array<unknown>; item?: unknown; items: Array<unknown> }> = async ({

--- a/packages/graphai/tests/test_agents/sleeper_agent.ts
+++ b/packages/graphai/tests/test_agents/sleeper_agent.ts
@@ -1,4 +1,4 @@
-import { AgentFunction, AgentFunctionInfo, sleep } from "@/index";
+import { AgentFunction, AgentFunctionInfo, sleep } from "../../src/index";
 
 export const sleeperAgent: AgentFunction<{ duration?: number }> = async ({ params, namedInputs }) => {
   await sleep(params?.duration ?? 10);

--- a/packages/graphai/tests/test_agents/stream_mock_agent.ts
+++ b/packages/graphai/tests/test_agents/stream_mock_agent.ts
@@ -1,5 +1,5 @@
-import { AgentFunction, AgentFunctionInfo } from "@/index";
-import { sleep } from "@/utils/utils";
+import { AgentFunction, AgentFunctionInfo } from "../../src/index";
+import { sleep } from "../../src/utils/utils";
 
 export const streamMockAgent: AgentFunction = async ({ params, filterParams }) => {
   const message = params.message || "";

--- a/packages/graphai/tests/units/graph_data.ts
+++ b/packages/graphai/tests/units/graph_data.ts
@@ -1,4 +1,4 @@
-import { graphDataLatestVersion } from "~/common";
+import { graphDataLatestVersion } from "../common";
 
 export const graph_data = {
   version: graphDataLatestVersion,

--- a/packages/graphai/tests/units/test_abort.ts
+++ b/packages/graphai/tests/units/test_abort.ts
@@ -1,7 +1,7 @@
-import { GraphAI, GraphData, sleep, NodeState } from "@/index";
-import { graphDataLatestVersion } from "~/common";
-import * as agents from "~/test_agents";
-import { AgentFilterFunction } from "@/type";
+import { GraphAI, GraphData, sleep, NodeState } from "../../src/index";
+import { graphDataLatestVersion } from "../common";
+import * as agents from "../test_agents";
+import { AgentFilterFunction } from "../../src/type";
 
 import test from "node:test";
 // import assert from "node:assert";

--- a/packages/graphai/tests/units/test_agent_filter_bypass.ts
+++ b/packages/graphai/tests/units/test_agent_filter_bypass.ts
@@ -1,6 +1,6 @@
-import { GraphAI } from "@/index";
-import { AgentFilterFunction } from "@/type";
-import { graph_data } from "~/units/graph_data";
+import { GraphAI } from "../../src/index";
+import { AgentFilterFunction } from "../../src/type";
+import { graph_data } from "../units/graph_data";
 
 import test from "node:test";
 import assert from "node:assert";

--- a/packages/graphai/tests/units/test_anon_agent.ts
+++ b/packages/graphai/tests/units/test_anon_agent.ts
@@ -1,5 +1,5 @@
-import { GraphAI } from "@/index";
-import { graphDataLatestVersion } from "~/common";
+import { GraphAI } from "../../src/index";
+import { graphDataLatestVersion } from "../common";
 import { nestedAgent } from "../test_agents";
 import test from "node:test";
 import assert from "node:assert";

--- a/packages/graphai/tests/units/test_clean_result.ts
+++ b/packages/graphai/tests/units/test_clean_result.ts
@@ -1,4 +1,4 @@
-import { cleanResult } from "@/utils/result";
+import { cleanResult } from "../../src/utils/result";
 
 import test from "node:test";
 import assert from "node:assert";

--- a/packages/graphai/tests/units/test_computed_node.ts
+++ b/packages/graphai/tests/units/test_computed_node.ts
@@ -1,7 +1,7 @@
-import { GraphAI, NodeState } from "@/index";
-import { ComputedNode } from "@/node";
+import { GraphAI, NodeState } from "../../src/index";
+import { ComputedNode } from "../../src/node";
 
-import { graph_data } from "~/units/graph_data";
+import { graph_data } from "../units/graph_data";
 
 import test from "node:test";
 import assert from "node:assert";

--- a/packages/graphai/tests/units/test_console.ts
+++ b/packages/graphai/tests/units/test_console.ts
@@ -1,8 +1,8 @@
-import { GraphAI } from "@/index";
+import { GraphAI } from "../../src/index";
 
-import * as agents from "~/test_agents";
+import * as agents from "../test_agents";
 
-import { graphDataLatestVersion } from "~/common";
+import { graphDataLatestVersion } from "../common";
 
 import test from "node:test";
 

--- a/packages/graphai/tests/units/test_data_sources.ts
+++ b/packages/graphai/tests/units/test_data_sources.ts
@@ -1,5 +1,5 @@
-import { parseNodeName } from "@/utils/utils";
-import { getDataFromSource } from "@/utils/data_source";
+import { parseNodeName } from "../../src/utils/utils";
+import { getDataFromSource } from "../../src/utils/data_source";
 
 import test from "node:test";
 import assert from "node:assert";

--- a/packages/graphai/tests/units/test_default_value.ts
+++ b/packages/graphai/tests/units/test_default_value.ts
@@ -1,6 +1,6 @@
-import { GraphAI } from "@/index";
-import { graphDataLatestVersion } from "~/common";
-import * as agents from "~/test_agents";
+import { GraphAI } from "../../src/index";
+import { graphDataLatestVersion } from "../common";
+import * as agents from "../test_agents";
 
 import test from "node:test";
 import assert from "node:assert";

--- a/packages/graphai/tests/units/test_dynamic_agent.ts
+++ b/packages/graphai/tests/units/test_dynamic_agent.ts
@@ -1,5 +1,5 @@
-import { GraphAI } from "@/index";
-import { graphDataLatestVersion } from "~/common";
+import { GraphAI } from "../../src/index";
+import { graphDataLatestVersion } from "../common";
 import { copyAgent } from "../test_agents";
 import test from "node:test";
 import assert from "node:assert";

--- a/packages/graphai/tests/units/test_dynamic_params.ts
+++ b/packages/graphai/tests/units/test_dynamic_params.ts
@@ -1,6 +1,6 @@
-import { GraphAI } from "@/index";
-import { graphDataLatestVersion } from "~/common";
-import * as agents from "~/test_agents";
+import { GraphAI } from "../../src/index";
+import { graphDataLatestVersion } from "../common";
+import * as agents from "../test_agents";
 
 import test from "node:test";
 import assert from "node:assert";

--- a/packages/graphai/tests/units/test_error.ts
+++ b/packages/graphai/tests/units/test_error.ts
@@ -1,8 +1,8 @@
-import { GraphAI } from "@/index";
+import { GraphAI } from "../../src/index";
 
-import * as agents from "~/test_agents";
+import * as agents from "../test_agents";
 
-import { graphDataLatestVersion } from "~/common";
+import { graphDataLatestVersion } from "../common";
 import { anonymization } from "@receptron/test_utils";
 
 import test from "node:test";

--- a/packages/graphai/tests/units/test_graph.ts
+++ b/packages/graphai/tests/units/test_graph.ts
@@ -1,7 +1,7 @@
-import { GraphAI, GraphData } from "@/index";
-import { graphDataLatestVersion } from "~/common";
-import * as agents from "~/test_agents";
-import { GraphDataLoaderOption } from "@/type";
+import { GraphAI, GraphData } from "../../src/index";
+import { graphDataLatestVersion } from "../common";
+import * as agents from "../test_agents";
+import { GraphDataLoaderOption } from "../../src/type";
 
 import test from "node:test";
 import assert from "node:assert";

--- a/packages/graphai/tests/units/test_injections.ts
+++ b/packages/graphai/tests/units/test_injections.ts
@@ -1,5 +1,5 @@
-import { GraphAI } from "@/index";
-import { graphDataLatestVersion } from "~/common";
+import { GraphAI } from "../../src/index";
+import { graphDataLatestVersion } from "../common";
 import { copyAgent } from "../test_agents";
 import test from "node:test";
 import assert from "node:assert";

--- a/packages/graphai/tests/units/test_inputs.ts
+++ b/packages/graphai/tests/units/test_inputs.ts
@@ -1,5 +1,5 @@
-import { GraphAI } from "@/index";
-import { graphDataLatestVersion } from "~/common";
+import { GraphAI } from "../../src/index";
+import { graphDataLatestVersion } from "../common";
 import { nestedAgent } from "../test_agents";
 import test from "node:test";
 import assert from "node:assert";

--- a/packages/graphai/tests/units/test_is_named_inputs.ts
+++ b/packages/graphai/tests/units/test_is_named_inputs.ts
@@ -1,4 +1,4 @@
-import { isNamedInputs } from "@/utils/utils";
+import { isNamedInputs } from "../../src/utils/utils";
 
 import test from "node:test";
 import assert from "node:assert";

--- a/packages/graphai/tests/units/test_logcallback.ts
+++ b/packages/graphai/tests/units/test_logcallback.ts
@@ -1,6 +1,6 @@
-import { GraphAI, GraphData } from "@/index";
-import { graphDataLatestVersion } from "~/common";
-import * as agents from "~/test_agents";
+import { GraphAI, GraphData } from "../../src/index";
+import { graphDataLatestVersion } from "../common";
+import * as agents from "../test_agents";
 
 import test from "node:test";
 import assert from "node:assert";

--- a/packages/graphai/tests/units/test_loop.ts
+++ b/packages/graphai/tests/units/test_loop.ts
@@ -1,8 +1,8 @@
-import { GraphAI } from "@/index";
+import { GraphAI } from "../../src/index";
 
-import * as agents from "~/test_agents";
+import * as agents from "../test_agents";
 
-import { graphDataLatestVersion } from "~/common";
+import { graphDataLatestVersion } from "../common";
 
 import test from "node:test";
 import assert from "node:assert";

--- a/packages/graphai/tests/units/test_manually_loop.ts
+++ b/packages/graphai/tests/units/test_manually_loop.ts
@@ -1,6 +1,6 @@
-import { GraphAI } from "@/index";
-import { graphDataLatestVersion } from "~/common";
-import * as agents from "~/test_agents";
+import { GraphAI } from "../../src/index";
+import { graphDataLatestVersion } from "../common";
+import * as agents from "../test_agents";
 
 import test from "node:test";
 import assert from "node:assert";

--- a/packages/graphai/tests/units/test_named_data_sources.ts
+++ b/packages/graphai/tests/units/test_named_data_sources.ts
@@ -1,4 +1,4 @@
-import { inputs2dataSources, dataSourceNodeIds } from "@/utils/nodeUtils";
+import { inputs2dataSources, dataSourceNodeIds } from "../../src/utils/nodeUtils";
 
 import test from "node:test";
 import assert from "node:assert";

--- a/packages/graphai/tests/units/test_named_inputs.ts
+++ b/packages/graphai/tests/units/test_named_inputs.ts
@@ -1,7 +1,7 @@
-import { GraphAI } from "@/index";
-import { graphDataLatestVersion } from "~/common";
+import { GraphAI } from "../../src/index";
+import { graphDataLatestVersion } from "../common";
 
-import * as agents from "~/test_agents";
+import * as agents from "../test_agents";
 
 import test from "node:test";
 import assert from "node:assert";

--- a/packages/graphai/tests/units/test_node.ts
+++ b/packages/graphai/tests/units/test_node.ts
@@ -1,8 +1,8 @@
-import { GraphAI } from "@/index";
-import { StaticNode } from "@/node";
-import { NodeState } from "@/type";
+import { GraphAI } from "../../src/index";
+import { StaticNode } from "../../src/node";
+import { NodeState } from "../../src/type";
 
-import { graph_data } from "~/units/graph_data";
+import { graph_data } from "../units/graph_data";
 
 import test from "node:test";
 import assert from "node:assert";

--- a/packages/graphai/tests/units/test_option_config.ts
+++ b/packages/graphai/tests/units/test_option_config.ts
@@ -1,5 +1,5 @@
-import { GraphAI, AgentFunction, agentInfoWrapper } from "@/index";
-import { graphDataLatestVersion } from "~/common";
+import { GraphAI, AgentFunction, agentInfoWrapper } from "../../src/index";
+import { graphDataLatestVersion } from "../common";
 import * as testAgents from "../test_agents";
 
 import test from "node:test";

--- a/packages/graphai/tests/units/test_output.ts
+++ b/packages/graphai/tests/units/test_output.ts
@@ -1,6 +1,6 @@
-import { GraphAI } from "@/index";
-import { graphDataLatestVersion } from "~/common";
-import * as agents from "~/test_agents";
+import { GraphAI } from "../../src/index";
+import { graphDataLatestVersion } from "../common";
+import * as agents from "../test_agents";
 
 import test from "node:test";
 import assert from "node:assert";

--- a/packages/graphai/tests/units/test_params.ts
+++ b/packages/graphai/tests/units/test_params.ts
@@ -1,6 +1,6 @@
 import "dotenv/config";
 import { GraphAI } from "../../src";
-import * as agents from "~/test_agents";
+import * as agents from "../test_agents";
 
 import test from "node:test";
 import assert from "node:assert";

--- a/packages/graphai/tests/units/test_passthrough.ts
+++ b/packages/graphai/tests/units/test_passthrough.ts
@@ -1,7 +1,7 @@
-import { GraphAI } from "@/index";
+import { GraphAI } from "../../src/index";
 
-import { graph_data_passthrough, graph_data_passthrough2, graph_data_passthrough_god, graph_data_passthrough_god_out } from "~/units/graph_data";
-import * as agents from "~/test_agents";
+import { graph_data_passthrough, graph_data_passthrough2, graph_data_passthrough_god, graph_data_passthrough_god_out } from "../units/graph_data";
+import * as agents from "../test_agents";
 
 import test from "node:test";
 import assert from "node:assert";

--- a/packages/graphai/tests/units/test_result.ts
+++ b/packages/graphai/tests/units/test_result.ts
@@ -1,9 +1,9 @@
-import { graphDataLatestVersion } from "~/common";
-import { StaticNode, ComputedNode } from "@/node";
-import { resultsOf, cleanResult } from "@/utils/result";
-import { propFunctions } from "@/utils/prop_function";
-import { TaskManager } from "@/task_manager";
-import { GraphAI } from "@/graphai";
+import { graphDataLatestVersion } from "../common";
+import { StaticNode, ComputedNode } from "../../src/node";
+import { resultsOf, cleanResult } from "../../src/utils/result";
+import { propFunctions } from "../../src/utils/prop_function";
+import { TaskManager } from "../../src/task_manager";
+import { GraphAI } from "../../src/graphai";
 
 // import { graph_data } from "./graph_data";
 import * as agents from "../test_agents";

--- a/packages/graphai/tests/units/test_result_key.ts
+++ b/packages/graphai/tests/units/test_result_key.ts
@@ -1,4 +1,4 @@
-import { debugResultKey } from "@/utils/utils";
+import { debugResultKey } from "../../src/utils/utils";
 
 import test from "node:test";
 import assert from "node:assert";

--- a/packages/graphai/tests/units/test_retry.ts
+++ b/packages/graphai/tests/units/test_retry.ts
@@ -1,8 +1,8 @@
-import { GraphAI } from "@/index";
+import { GraphAI } from "../../src/index";
 
-import * as agents from "~/test_agents";
+import * as agents from "../test_agents";
 
-import { graphDataLatestVersion } from "~/common";
+import { graphDataLatestVersion } from "../common";
 
 import test from "node:test";
 import assert from "node:assert";

--- a/packages/graphai/tests/validators/test_validator_agent.ts
+++ b/packages/graphai/tests/validators/test_validator_agent.ts
@@ -1,7 +1,7 @@
 import { anonymization } from "@receptron/test_utils";
-import { validateAgent, validateGraphData } from "@/validator";
-import { ValidationError } from "@/validators/common";
-import { graphDataLatestVersion } from "~/common";
+import { validateAgent, validateGraphData } from "../../src/validator";
+import { ValidationError } from "../../src/validators/common";
+import { graphDataLatestVersion } from "../common";
 
 import test from "node:test";
 import assert from "node:assert";

--- a/packages/graphai/tests/validators/test_validator_computed_node.ts
+++ b/packages/graphai/tests/validators/test_validator_computed_node.ts
@@ -1,5 +1,5 @@
 import { anonymization, rejectTest } from "@receptron/test_utils";
-import { graphDataLatestVersion } from "~/common";
+import { graphDataLatestVersion } from "../common";
 
 import test from "node:test";
 

--- a/packages/graphai/tests/validators/test_validator_graph_data.ts
+++ b/packages/graphai/tests/validators/test_validator_graph_data.ts
@@ -1,6 +1,6 @@
 import { anonymization, rejectTest } from "@receptron/test_utils";
-import { graphDataLatestVersion } from "~/common";
-import { validateGraphData } from "@/validator";
+import { graphDataLatestVersion } from "../common";
+import { validateGraphData } from "../../src/validator";
 
 import test from "node:test";
 

--- a/packages/graphai/tests/validators/test_validator_inputs.ts
+++ b/packages/graphai/tests/validators/test_validator_inputs.ts
@@ -1,5 +1,5 @@
 import { anonymization, rejectTest } from "@receptron/test_utils";
-import { graphDataLatestVersion } from "~/common";
+import { graphDataLatestVersion } from "../common";
 
 import test from "node:test";
 

--- a/packages/graphai/tests/validators/test_validator_named_inputs.ts
+++ b/packages/graphai/tests/validators/test_validator_named_inputs.ts
@@ -1,5 +1,5 @@
 import { anonymization, rejectTest } from "@receptron/test_utils";
-import { graphDataLatestVersion } from "~/common";
+import { graphDataLatestVersion } from "../common";
 
 import test from "node:test";
 

--- a/packages/graphai/tests/validators/test_validator_nodes.ts
+++ b/packages/graphai/tests/validators/test_validator_nodes.ts
@@ -1,5 +1,5 @@
 import { anonymization, rejectTest } from "@receptron/test_utils";
-import { graphDataLatestVersion } from "~/common";
+import { graphDataLatestVersion } from "../common";
 
 import test from "node:test";
 

--- a/packages/graphai/tests/validators/test_validator_static_node.ts
+++ b/packages/graphai/tests/validators/test_validator_static_node.ts
@@ -2,7 +2,7 @@ import { anonymization, rejectTest } from "@receptron/test_utils";
 
 import test from "node:test";
 
-import { graphDataLatestVersion } from "~/common";
+import { graphDataLatestVersion } from "../common";
 
 test("test static node validation inputs", async () => {
   const graph_data = anonymization({

--- a/packages/graphai/tsconfig.json
+++ b/packages/graphai/tsconfig.json
@@ -1,13 +1,9 @@
 {
   "extends": "../../config/tsconfig.base.json",
   "compilerOptions": {
-    "baseUrl": "./", 
+    "baseUrl": "./",
     "rootDir": "./src/",
-    "outDir": "./lib",
-    "paths": {
-      "@/*": ["./src/*"],
-      "~/*": ["./tests/*"],
-    }
+    "outDir": "./lib"
   },
   "include": ["src"]
 }


### PR DESCRIPTION
## Summary
- remove `tsconfig-paths` and `tsc-alias` usage from `graphai`
- drop path mappings from tsconfig
- convert `@/` and `~/` imports in tests to relative paths
- update test command

## Testing
- `npm test` *(fails: Cannot find module 'ts-node/register')*

------
https://chatgpt.com/codex/tasks/task_e_6867386e14808333a1f6030bc88ecfeb