### PR TITLE
Remove path alias usage in agents package

### DIFF
--- a/packages/agents/package.json
+++ b/packages/agents/package.json
@@ -7,13 +7,13 @@
     "./lib"
   ],
   "scripts": {
-    "build": "rm -r lib/* && tsc && tsc-alias",
+    "build": "rm -r lib/* && tsc",
     "eslint": "eslint",
     "doc": "npm run examplesDoc && npx agentdoc",
-    "examplesDoc": "npx ts-node  -r tsconfig-paths/register tests/graphai/examples.ts",
+    "examplesDoc": "npx ts-node tests/graphai/examples.ts",
     "format": "prettier --write '{src,tests,samples}/**/*.ts'",
-    "test": "node --test  -r tsconfig-paths/register --require ts-node/register ./tests/**/test_*.ts",
-    "http_test": "node --test  -r tsconfig-paths/register --require ts-node/register ./tests/**/http_*.ts",
+    "test": "node --test --require ts-node/register ./tests/**/test_*.ts",
+    "http_test": "node --test --require ts-node/register ./tests/**/http_*.ts",
     "b": "yarn run format && yarn run eslint && yarn run build"
   },
   "repository": {

--- a/packages/agents/tests/graphai/test_any.ts
+++ b/packages/agents/tests/graphai/test_any.ts
@@ -1,6 +1,6 @@
 import { GraphAI } from "graphai";
 import { graphDataTestRunner } from "@receptron/test_utils";
-import * as agents from "@/index";
+import * as agents from "../../src/index";
 
 import { graphDataAny, graphDataAny2 } from "./graphData";
 

--- a/packages/agents/tests/graphai/test_dispatch.ts
+++ b/packages/agents/tests/graphai/test_dispatch.ts
@@ -1,6 +1,6 @@
 import { AgentFunction, sleep, agentInfoWrapper } from "graphai";
 
-import * as agents from "@/index";
+import * as agents from "../../src/index";
 import { fileTestRunner } from "@receptron/test_utils";
 
 import test from "node:test";

--- a/packages/agents/tests/graphai/test_inputs.ts
+++ b/packages/agents/tests/graphai/test_inputs.ts
@@ -1,5 +1,5 @@
 import { graphDataTestRunner } from "@receptron/test_utils";
-import { sleepAndMergeAgent } from "@/index";
+import { sleepAndMergeAgent } from "../../src/index";
 
 import { graphDataInputs } from "./graphData";
 

--- a/packages/agents/tests/graphai/test_nest.ts
+++ b/packages/agents/tests/graphai/test_nest.ts
@@ -1,6 +1,6 @@
 import { GraphAI } from "graphai";
 import { graphDataTestRunner } from "@receptron/test_utils";
-import { nestedAgent, copyAgent, propertyFilterAgent, mapAgent } from "@/index";
+import { nestedAgent, copyAgent, propertyFilterAgent, mapAgent } from "../../src/index";
 
 import { validChildGraph, graphDataNested } from "./graphData";
 

--- a/packages/agents/tests/graphai/test_params.ts
+++ b/packages/agents/tests/graphai/test_params.ts
@@ -1,7 +1,7 @@
 import { AgentFunction, agentInfoWrapper } from "graphai";
 import { graphDataTestRunner } from "@receptron/test_utils";
 
-import * as agents from "@/index";
+import * as agents from "../../src/index";
 
 import test from "node:test";
 import assert from "node:assert";

--- a/packages/agents/tests/graphai/test_sample_flow.ts
+++ b/packages/agents/tests/graphai/test_sample_flow.ts
@@ -1,7 +1,7 @@
 import { GraphAI, strIntentionalError } from "graphai";
 import { fileTestRunner, rejectFileTest } from "@receptron/test_utils";
 
-import * as agents from "@/index";
+import * as agents from "../../src/index";
 
 import test from "node:test";
 import assert from "node:assert";

--- a/packages/agents/tests/graphai/test_simple_dispatch.ts
+++ b/packages/agents/tests/graphai/test_simple_dispatch.ts
@@ -1,6 +1,6 @@
 import { AgentFunction, agentInfoWrapper } from "graphai";
 import { graphDataTestRunner, fileBaseName } from "@receptron/test_utils";
-import * as agents from "@/index";
+import * as agents from "../../src/index";
 
 import test from "node:test";
 import assert from "node:assert";

--- a/packages/agents/tests/graphai/test_source_prop.ts
+++ b/packages/agents/tests/graphai/test_source_prop.ts
@@ -1,6 +1,6 @@
 import { AgentFunction } from "graphai";
 import { graphDataTestRunner } from "@receptron/test_utils";
-import * as agents from "@/index";
+import * as agents from "../../src/index";
 import { agentInfoWrapper } from "graphai";
 
 import { graphDataLiteral } from "./graphData";

--- a/packages/agents/tests/graphai/test_streamer.ts
+++ b/packages/agents/tests/graphai/test_streamer.ts
@@ -1,5 +1,5 @@
 import { graphDataTestRunner } from "@receptron/test_utils";
-import * as agents from "@/index";
+import * as agents from "../../src/index";
 
 import test from "node:test";
 import assert from "node:assert";

--- a/packages/agents/tsconfig.json
+++ b/packages/agents/tsconfig.json
@@ -3,10 +3,7 @@
   "compilerOptions": {
     "baseUrl": "./",
     "rootDir": "./src/",
-    "outDir": "./lib",
-    "paths": {
-      "@/*": ["./src/*"]
-    }
+    "outDir": "./lib"
   },
   "include": ["src"]
 }


### PR DESCRIPTION
## Summary
- remove alias usage from `packages/agents`
- convert tests to relative imports
- drop `tsconfig-paths/register` and `tsc-alias` from package scripts
- cleanup `tsconfig.json`

## Testing
- `yarn workspace @graphai/agents run test` *(fails: package not in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_68673c1cc1e8833383fda377807e1a32