### PR TITLE
Remove tsconfig-path alias usage in llm_agents

### DIFF
--- a/llm_agents/anthropic_agent/tsconfig.json
+++ b/llm_agents/anthropic_agent/tsconfig.json
@@ -3,10 +3,9 @@
   "compilerOptions": {
     "baseUrl": "./",
     "rootDir": "./src/",
-    "outDir": "./lib",
-    "paths": {
-      "@/*": ["./src/*"]
-    }
+    "outDir": "./lib"
   },
-  "include": ["src"]
+  "include": [
+    "src"
+  ]
 }

--- a/llm_agents/gemini_agent/package.json
+++ b/llm_agents/gemini_agent/package.json
@@ -7,13 +7,13 @@
     "./lib"
   ],
   "scripts": {
-    "build": "rm -r lib/* && tsc && tsc-alias",
+    "build": "rm -r lib/* && tsc",
     "eslint": "eslint",
     "format": "prettier --write '{src,tests,samples}/**/*.ts'",
     "doc": "npm run examplesDoc && npx agentdoc",
-    "examplesDoc": "npx ts-node  -r tsconfig-paths/register tests/examples.ts",
+    "examplesDoc": "npx ts-node  tests/examples.ts",
     "test": "echo hello",
-    "test_run": "node --test  -r tsconfig-paths/register --require ts-node/register ./tests/run_*.ts # just run locally",
+    "test_run": "node --test  --require ts-node/register ./tests/run_*.ts # just run locally",
     "b": "yarn run format && yarn run eslint && yarn run build"
   },
   "repository": {

--- a/llm_agents/gemini_agent/tests/run_gemini_graph.ts
+++ b/llm_agents/gemini_agent/tests/run_gemini_graph.ts
@@ -1,5 +1,5 @@
 import "dotenv/config";
-import * as agent from "@/index";
+import * as agent from "../src/index";
 
 import { graphDataTestRunner } from "@receptron/test_utils";
 

--- a/llm_agents/gemini_agent/tsconfig.json
+++ b/llm_agents/gemini_agent/tsconfig.json
@@ -3,10 +3,9 @@
   "compilerOptions": {
     "baseUrl": "./",
     "rootDir": "./src/",
-    "outDir": "./lib",
-    "paths": {
-      "@/*": ["./src/*"]
-    }
+    "outDir": "./lib"
   },
-  "include": ["src"]
+  "include": [
+    "src"
+  ]
 }

--- a/llm_agents/groq_agent/package.json
+++ b/llm_agents/groq_agent/package.json
@@ -7,13 +7,13 @@
     "./lib"
   ],
   "scripts": {
-    "build": "rm -r lib/* && tsc && tsc-alias",
+    "build": "rm -r lib/* && tsc",
     "eslint": "eslint",
     "format": "prettier --write '{src,tests,samples}/**/*.ts'",
     "doc": "npm run examplesDoc && npx agentdoc",
-    "examplesDoc": "npx ts-node  -r tsconfig-paths/register tests/examples.ts",
+    "examplesDoc": "npx ts-node  tests/examples.ts",
     "test": "echo hello",
-    "test_run": "node --test  -r tsconfig-paths/register --require ts-node/register ./tests/run_*.ts # just run locally",
+    "test_run": "node --test  --require ts-node/register ./tests/run_*.ts # just run locally",
     "b": "yarn run format && yarn run eslint && yarn run build"
   },
   "repository": {

--- a/llm_agents/groq_agent/tests/run_groq.ts
+++ b/llm_agents/groq_agent/tests/run_groq.ts
@@ -1,6 +1,6 @@
 import "dotenv/config";
 import { defaultTestContext } from "graphai";
-import { groqAgent } from "@/groq_agent";
+import { groqAgent } from "../src/groq_agent";
 
 import test from "node:test";
 import assert from "node:assert";

--- a/llm_agents/groq_agent/tests/run_groq_graph.ts
+++ b/llm_agents/groq_agent/tests/run_groq_graph.ts
@@ -1,5 +1,5 @@
 import "dotenv/config";
-import * as agent from "@/index";
+import * as agent from "../src/index";
 
 import { graphDataTestRunner } from "@receptron/test_utils";
 

--- a/llm_agents/groq_agent/tsconfig.json
+++ b/llm_agents/groq_agent/tsconfig.json
@@ -3,10 +3,9 @@
   "compilerOptions": {
     "baseUrl": "./",
     "rootDir": "./src/",
-    "outDir": "./lib",
-    "paths": {
-      "@/*": ["./src/*"]
-    }
+    "outDir": "./lib"
   },
-  "include": ["src"]
+  "include": [
+    "src"
+  ]
 }

--- a/llm_agents/llm_utils/package.json
+++ b/llm_agents/llm_utils/package.json
@@ -7,11 +7,11 @@
     "./lib"
   ],
   "scripts": {
-    "build": "rm -r lib/* && tsc && tsc-alias",
+    "build": "rm -r lib/* && tsc",
     "eslint": "eslint",
     "format": "prettier --write '{src,tests,samples}/**/*.ts'",
     "doc": "echo nothing",
-    "test": "node --test  -r tsconfig-paths/register --require ts-node/register ./tests/test_*.ts",
+    "test": "node --test  --require ts-node/register ./tests/test_*.ts",
     "b": "yarn run format && yarn run eslint && yarn run build"
   },
   "repository": {
@@ -24,8 +24,7 @@
     "url": "https://github.com/receptron/graphai/issues"
   },
   "homepage": "https://github.com/receptron/graphai/blob/main/llm_agents/llm_utils/README.md",
-  "dependencies": {
-  },
+  "dependencies": {},
   "devDependencies": {},
   "types": "./lib/index.d.ts",
   "directories": {

--- a/llm_agents/llm_utils/tests/test_utils.ts
+++ b/llm_agents/llm_utils/tests/test_utils.ts
@@ -1,4 +1,4 @@
-import { flatString, getMergeValue, getMessages } from "@/index";
+import { flatString, getMergeValue, getMessages } from "../src/index";
 
 import test from "node:test";
 import assert from "node:assert";

--- a/llm_agents/llm_utils/tsconfig.json
+++ b/llm_agents/llm_utils/tsconfig.json
@@ -3,10 +3,9 @@
   "compilerOptions": {
     "baseUrl": "./",
     "rootDir": "./src/",
-    "outDir": "./lib",
-    "paths": {
-      "@/*": ["./src/*"]
-    }
+    "outDir": "./lib"
   },
-  "include": ["src"]
+  "include": [
+    "src"
+  ]
 }

--- a/llm_agents/openai_agent/package.json
+++ b/llm_agents/openai_agent/package.json
@@ -7,14 +7,14 @@
     "./lib"
   ],
   "scripts": {
-    "build": "rm -r lib/* && tsc && tsc-alias",
+    "build": "rm -r lib/* && tsc",
     "eslint": "eslint",
     "format": "prettier --write '{src,tests,samples}/**/*.ts'",
     "doc": "npm run examplesDoc && npx agentdoc",
-    "examplesDoc": "npx ts-node  -r tsconfig-paths/register tests/examples.ts",
+    "examplesDoc": "npx ts-node  tests/examples.ts",
     "test": "echo nothing",
-    "test_run": "node --test  -r tsconfig-paths/register --require ts-node/register ./tests/run_*.ts # just run locally",
-    "chat": "node -r tsconfig-paths/register -r ts-node/register ./tests/chat_dispatch.ts",
+    "test_run": "node --test  --require ts-node/register ./tests/run_*.ts # just run locally",
+    "chat": "node -r ts-node/register ./tests/chat_dispatch.ts",
     "b": "yarn run format && yarn run eslint && yarn run build"
   },
   "repository": {

--- a/llm_agents/openai_agent/tests/chat_dispatch.ts
+++ b/llm_agents/openai_agent/tests/chat_dispatch.ts
@@ -1,5 +1,5 @@
 import "dotenv/config";
-import * as agent from "@/index";
+import * as agent from "../src/index";
 import { textInputAgent } from "@graphai/input_agents";
 import * as vanilla from "@graphai/vanilla";
 import { GraphAI } from "graphai";

--- a/llm_agents/openai_agent/tests/run_ollama.ts
+++ b/llm_agents/openai_agent/tests/run_ollama.ts
@@ -1,6 +1,6 @@
 import "dotenv/config";
 import { defaultTestContext } from "graphai";
-import { openAIAgent } from "@/openai_agent";
+import { openAIAgent } from "../src/openai_agent";
 
 import test from "node:test";
 import assert from "node:assert";

--- a/llm_agents/openai_agent/tests/run_openai_graph.ts
+++ b/llm_agents/openai_agent/tests/run_openai_graph.ts
@@ -1,5 +1,5 @@
 import "dotenv/config";
-import * as agent from "@/index";
+import * as agent from "../src/index";
 
 import { graphDataTestRunner } from "@receptron/test_utils";
 

--- a/llm_agents/openai_agent/tsconfig.json
+++ b/llm_agents/openai_agent/tsconfig.json
@@ -3,10 +3,9 @@
   "compilerOptions": {
     "baseUrl": "./",
     "rootDir": "./src/",
-    "outDir": "./lib",
-    "paths": {
-      "@/*": ["./src/*"]
-    }
+    "outDir": "./lib"
   },
-  "include": ["src"]
+  "include": [
+    "src"
+  ]
 }

--- a/llm_agents/openai_fetch_agent/package.json
+++ b/llm_agents/openai_fetch_agent/package.json
@@ -9,14 +9,14 @@
     "./lib"
   ],
   "scripts": {
-    "build": "rm -r lib/* && tsc && npx rollup -c && tsc-alias",
+    "build": "rm -r lib/* && tsc && npx rollup -c",
     "eslint": "eslint",
     "format": "prettier --write '{src,tests,samples}/**/*.ts'",
     "doc": "npm run examplesDoc && npx agentdoc",
-    "examplesDoc": "npx ts-node  -r tsconfig-paths/register tests/examples.ts",
+    "examplesDoc": "npx ts-node  tests/examples.ts",
     "test": "echo nothing",
-    "test_run": "node --test  -r tsconfig-paths/register --require ts-node/register ./tests/run_*.ts # just run locally",
-    "chat": "node -r tsconfig-paths/register -r ts-node/register ./tests/chat_dispatch.ts",
+    "test_run": "node --test  --require ts-node/register ./tests/run_*.ts # just run locally",
+    "chat": "node -r ts-node/register ./tests/chat_dispatch.ts",
     "b": "yarn run format && yarn run eslint && yarn run build"
   },
   "repository": {

--- a/llm_agents/openai_fetch_agent/tests/run_openai.ts
+++ b/llm_agents/openai_fetch_agent/tests/run_openai.ts
@@ -1,5 +1,5 @@
 import "dotenv/config";
-import { openAIFetchAgent } from "@/openai_fetch_agent";
+import { openAIFetchAgent } from "../src/openai_fetch_agent";
 
 import test from "node:test";
 import assert from "node:assert";

--- a/llm_agents/openai_fetch_agent/tsconfig.json
+++ b/llm_agents/openai_fetch_agent/tsconfig.json
@@ -3,10 +3,9 @@
   "compilerOptions": {
     "baseUrl": "./",
     "rootDir": "./src/",
-    "outDir": "./lib",
-    "paths": {
-      "@/*": ["./src/*"]
-    }
+    "outDir": "./lib"
   },
-  "include": ["src"]
+  "include": [
+    "src"
+  ]
 }

--- a/llm_agents/replicate_agent/package.json
+++ b/llm_agents/replicate_agent/package.json
@@ -7,13 +7,13 @@
     "./lib"
   ],
   "scripts": {
-    "build": "rm -r lib/* && tsc && tsc-alias",
+    "build": "rm -r lib/* && tsc",
     "eslint": "eslint",
     "format": "prettier --write '{src,tests,samples}/**/*.ts'",
     "doc": "npm run examplesDoc && npx agentdoc",
-    "examplesDoc": "npx ts-node  -r tsconfig-paths/register tests/examples.ts",
+    "examplesDoc": "npx ts-node  tests/examples.ts",
     "test": "echo nothing",
-    "test_run": "node --test  -r tsconfig-paths/register --require ts-node/register ./tests/run_*.ts # just run locally",
+    "test_run": "node --test  --require ts-node/register ./tests/run_*.ts # just run locally",
     "b": "yarn run format && yarn run eslint && yarn run build"
   },
   "repository": {

--- a/llm_agents/replicate_agent/tests/run_replicate.ts
+++ b/llm_agents/replicate_agent/tests/run_replicate.ts
@@ -1,6 +1,6 @@
 import "dotenv/config";
 import { defaultTestContext } from "graphai";
-import { replicateAgent } from "@/replicate_agent";
+import { replicateAgent } from "../src/replicate_agent";
 
 import test from "node:test";
 import assert from "node:assert";

--- a/llm_agents/replicate_agent/tests/run_replicate_graph.ts
+++ b/llm_agents/replicate_agent/tests/run_replicate_graph.ts
@@ -1,5 +1,5 @@
 import "dotenv/config";
-import * as agent from "@/index";
+import * as agent from "../src/index";
 
 import { graphDataTestRunner } from "@receptron/test_utils";
 

--- a/llm_agents/replicate_agent/tsconfig.json
+++ b/llm_agents/replicate_agent/tsconfig.json
@@ -3,10 +3,9 @@
   "compilerOptions": {
     "baseUrl": "./",
     "rootDir": "./src/",
-    "outDir": "./lib",
-    "paths": {
-      "@/*": ["./src/*"]
-    }
+    "outDir": "./lib"
   },
-  "include": ["src"]
+  "include": [
+    "src"
+  ]
 }

--- a/llm_agents/slashgpt_agent/package.json
+++ b/llm_agents/slashgpt_agent/package.json
@@ -7,12 +7,12 @@
     "./lib"
   ],
   "scripts": {
-    "build": "rm -r lib/* && tsc && tsc-alias",
+    "build": "rm -r lib/* && tsc",
     "eslint": "eslint",
     "format": "prettier --write '{src,tests,samples}/**/*.ts'",
     "doc": "npx agentdoc",
     "test": "echo hello",
-    "test_run": "node --test  -r tsconfig-paths/register --require ts-node/register ./tests/run_*.ts # just run locally",
+    "test_run": "node --test  --require ts-node/register ./tests/run_*.ts # just run locally",
     "b": "yarn run format && yarn run eslint && yarn run build"
   },
   "repository": {

--- a/llm_agents/slashgpt_agent/tests/run_slashgpt.ts
+++ b/llm_agents/slashgpt_agent/tests/run_slashgpt.ts
@@ -1,5 +1,5 @@
 import "dotenv/config";
-import { slashGPTAgent } from "@/slashgpt_agent";
+import { slashGPTAgent } from "../src/slashgpt_agent";
 
 import test from "node:test";
 import assert from "node:assert";

--- a/llm_agents/slashgpt_agent/tsconfig.json
+++ b/llm_agents/slashgpt_agent/tsconfig.json
@@ -3,10 +3,9 @@
   "compilerOptions": {
     "baseUrl": "./",
     "rootDir": "./src/",
-    "outDir": "./lib",
-    "paths": {
-      "@/*": ["./src/*"]
-    }
+    "outDir": "./lib"
   },
-  "include": ["src"]
+  "include": [
+    "src"
+  ]
 }

--- a/llm_agents/token_bound_string_agent/package.json
+++ b/llm_agents/token_bound_string_agent/package.json
@@ -7,11 +7,11 @@
     "./lib"
   ],
   "scripts": {
-    "build": "rm -r lib/* && tsc && tsc-alias",
+    "build": "rm -r lib/* && tsc",
     "eslint": "eslint",
     "format": "prettier --write '{src,tests,samples}/**/*.ts'",
     "doc": "npx agentdoc",
-    "test": "node --test  -r tsconfig-paths/register --require ts-node/register ./tests/test_*.ts",
+    "test": "node --test  --require ts-node/register ./tests/test_*.ts",
     "b": "yarn run format && yarn run eslint && yarn run build"
   },
   "repository": {

--- a/llm_agents/token_bound_string_agent/tests/test_agent_runner.ts
+++ b/llm_agents/token_bound_string_agent/tests/test_agent_runner.ts
@@ -1,4 +1,4 @@
-import { tokenBoundStringsAgent } from "@/index";
+import { tokenBoundStringsAgent } from "../src/index";
 import { agentTestRunner } from "@receptron/test_utils";
 
 const main = async () => {

--- a/llm_agents/token_bound_string_agent/tsconfig.json
+++ b/llm_agents/token_bound_string_agent/tsconfig.json
@@ -3,10 +3,9 @@
   "compilerOptions": {
     "baseUrl": "./",
     "rootDir": "./src/",
-    "outDir": "./lib",
-    "paths": {
-      "@/*": ["./src/*"]
-    }
+    "outDir": "./lib"
   },
-  "include": ["src"]
+  "include": [
+    "src"
+  ]
 }

--- a/llm_agents/tools_agent/package.json
+++ b/llm_agents/tools_agent/package.json
@@ -7,14 +7,14 @@
     "./lib"
   ],
   "scripts": {
-    "build": "rm -r lib/* && tsc && tsc-alias",
+    "build": "rm -r lib/* && tsc",
     "eslint": "eslint",
     "format": "prettier --write '{src,tests,samples}/**/*.ts'",
     "doc": "npx agentdoc",
-    "examplesDoc": "npx ts-node  -r tsconfig-paths/register tests/examples.ts",
+    "examplesDoc": "npx ts-node  tests/examples.ts",
     "test": "echo nothing",
-    "test_run": "node --test  -r tsconfig-paths/register --require ts-node/register ./tests/run_*.ts # just run locally",
-    "chat": "node -r tsconfig-paths/register -r ts-node/register ./tests/chat_dispatch.ts",
+    "test_run": "node --test  --require ts-node/register ./tests/run_*.ts # just run locally",
+    "chat": "node -r ts-node/register ./tests/chat_dispatch.ts",
     "b": "yarn run format && yarn run eslint && yarn run build"
   },
   "repository": {

--- a/llm_agents/tools_agent/tests/run_tools.ts
+++ b/llm_agents/tools_agent/tests/run_tools.ts
@@ -1,5 +1,5 @@
 import "dotenv/config";
-import { toolsAgent } from "@/index";
+import { toolsAgent } from "../src/index";
 
 import { AgentFunction, AgentFunctionInfo, defaultTestContext, agentInfoWrapper } from "graphai";
 

--- a/llm_agents/tools_agent/tsconfig.json
+++ b/llm_agents/tools_agent/tsconfig.json
@@ -3,10 +3,9 @@
   "compilerOptions": {
     "baseUrl": "./",
     "rootDir": "./src/",
-    "outDir": "./lib",
-    "paths": {
-      "@/*": ["./src/*"]
-    }
+    "outDir": "./lib"
   },
-  "include": ["src"]
+  "include": [
+    "src"
+  ]
 }


### PR DESCRIPTION
## Summary
- replace `@/` imports in tests with relative paths
- drop `tsc-alias` and `tsconfig-paths/register` from package scripts
- remove unused path mappings from `tsconfig.json`

## Testing
- `yarn test` *(fails: This package doesn't seem to be present in your lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_68673c03cd0883338dd152539d4435e2