### PR TITLE
Remove path alias configs from agent_filters

### DIFF
--- a/agent_filters/cache_agent_filter/tsconfig.json
+++ b/agent_filters/cache_agent_filter/tsconfig.json
@@ -3,10 +3,7 @@
   "compilerOptions": {
     "baseUrl": "./",
     "rootDir": "./src/",
-    "outDir": "./lib",
-    "paths": {
-      "@/*": ["./src/*"]
-    }
+    "outDir": "./lib"
   },
   "include": ["src"]
 }

--- a/agent_filters/http_client_agent_filter/tsconfig.json
+++ b/agent_filters/http_client_agent_filter/tsconfig.json
@@ -3,10 +3,7 @@
   "compilerOptions": {
     "baseUrl": "./",
     "rootDir": "./src/",
-    "outDir": "./lib",
-    "paths": {
-      "@/*": ["./src/*"]
-    }
+    "outDir": "./lib"
   },
   "include": ["src"]
 }

--- a/agent_filters/namedinput_validator_agent_filter/tsconfig.json
+++ b/agent_filters/namedinput_validator_agent_filter/tsconfig.json
@@ -3,10 +3,7 @@
   "compilerOptions": {
     "baseUrl": "./",
     "rootDir": "./src/",
-    "outDir": "./lib",
-    "paths": {
-      "@/*": ["./src/*"]
-    }
+    "outDir": "./lib"
   },
   "include": ["src"]
 }

--- a/agent_filters/step_runner_agent_filter/tsconfig.json
+++ b/agent_filters/step_runner_agent_filter/tsconfig.json
@@ -3,10 +3,7 @@
   "compilerOptions": {
     "baseUrl": "./",
     "rootDir": "./src/",
-    "outDir": "./lib",
-    "paths": {
-      "@/*": ["./src/*"]
-    }
+    "outDir": "./lib"
   },
   "include": ["src"]
 }

--- a/agent_filters/stream_agent_filter/tsconfig.json
+++ b/agent_filters/stream_agent_filter/tsconfig.json
@@ -3,10 +3,7 @@
   "compilerOptions": {
     "baseUrl": "./",
     "rootDir": "./src/",
-    "outDir": "./lib",
-    "paths": {
-      "@/*": ["./src/*"]
-    }
+    "outDir": "./lib"
   },
   "include": ["src"]
 }

--- a/agent_filters/utils/tsconfig.json
+++ b/agent_filters/utils/tsconfig.json
@@ -3,10 +3,7 @@
   "compilerOptions": {
     "baseUrl": "./",
     "rootDir": "./src/",
-    "outDir": "./lib",
-    "paths": {
-      "@/*": ["./src/*"]
-    }
+    "outDir": "./lib"
   },
   "include": ["src"]
 }

--- a/packages/agent_filters/package.json
+++ b/packages/agent_filters/package.json
@@ -12,7 +12,7 @@
     "format": "prettier --write '{src,tests,samples}/**/*.ts'",
     "test": "echo nothing",
     "doc": "echo nothing",
-    "http_server": "npx ts-node -r tsconfig-paths/register tests/express/server.ts",
+    "http_server": "npx ts-node tests/express/server.ts",
     "b": "yarn run format && yarn run eslint && yarn run build"
   },
   "repository": {

--- a/packages/agent_filters/tsconfig.json
+++ b/packages/agent_filters/tsconfig.json
@@ -3,10 +3,7 @@
   "compilerOptions": {
     "baseUrl": "./",
     "rootDir": "./src/",
-    "outDir": "./lib",
-    "paths": {
-      "@/*": ["./src/*"]
-    }
+    "outDir": "./lib"
   },
   "include": ["src"]
 }


### PR DESCRIPTION
## Summary
- drop `paths` alias configuration from all agent_filters packages
- simplify http_server script in packages/agent_filters

## Testing
- `yarn test` *(fails: graphai-wrapper@workspace:. is missing from lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_68673bdc72d483338c12b8a3bff3d730