### PR TITLE
Remove tsc-alias and path aliases

### DIFF
--- a/packages/agentdoc/package.json
+++ b/packages/agentdoc/package.json
@@ -16,7 +16,7 @@
     "eslint": "eslint --fix",
     "format": "prettier --write '{src,test_yaml,samples}/**/*.{yaml,ts,json}'",
     "doc": "echo nothing",
-    "test": "node --test  -r tsconfig-paths/register --require ts-node/register ./tests/test_*.ts",
+    "test": "node --test --require ts-node/register ./tests/test_*.ts",
     "b": "yarn run format && yarn run eslint && yarn run build"
   },
   "repository": {

--- a/packages/agentdoc/tests/test_doc.ts
+++ b/packages/agentdoc/tests/test_doc.ts
@@ -1,5 +1,5 @@
 import path from "path";
-import { getPackageJson, getAgents, getGitRep } from "@/agentdoc";
+import { getPackageJson, getAgents, getGitRep } from "../src/agentdoc";
 // import * as agents from "@graphai/agents"
 
 import test from "node:test";

--- a/packages/agentdoc/tsconfig.json
+++ b/packages/agentdoc/tsconfig.json
@@ -3,11 +3,7 @@
   "compilerOptions": {
     "baseUrl": "./", 
     "rootDir": "./src/",
-    "outDir": "./lib",
-    "paths": {
-      "@/*": ["./src/*"],
-      "~/*": ["./tests/*"],
-    }
+    "outDir": "./lib"
   },
   "include": ["src"]
 }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -10,14 +10,14 @@
     "./lib"
   ],
   "scripts": {
-    "build": "tsc && tsc-alias",
+    "build": "tsc",
     "eslint": "eslint --fix",
     "doc": "echo nothing",
     "format": "prettier --write '{src,test_yaml,samples}/**/*.{yaml,ts,json}'",
     "test": "yarn run test_sh",
     "test_sh": "./scripts/test.sh",
-    "test_node": "node --test  -r tsconfig-paths/register --require ts-node/register ./test_yaml/test_*.ts",
-    "cli": "node --require ts-node/register  -r tsconfig-paths/register ./src/graphai_cli.ts",
+    "test_node": "node --test --require ts-node/register ./test_yaml/test_*.ts",
+    "cli": "node --require ts-node/register ./src/graphai_cli.ts",
     "b": "yarn run format && yarn run eslint && yarn run build"
   },
   "repository": {

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -3,11 +3,7 @@
   "compilerOptions": {
     "baseUrl": "./", 
     "rootDir": "./src/",
-    "outDir": "./lib",
-    "paths": {
-      "@/*": ["./src/*"],
-      "~/*": ["./tests/*"],
-    }
+    "outDir": "./lib"
   },
   "include": ["src"]
 }

--- a/packages/lite/package.json
+++ b/packages/lite/package.json
@@ -7,9 +7,9 @@
     "./lib"
   ],
   "scripts": {
-    "build": "rm -r lib/* && tsc && tsc-alias",
+    "build": "rm -r lib/* && tsc",
     "eslint": "eslint",
-    "test": "node --test  -r tsconfig-paths/register --require ts-node/register ./tests/test_*.ts",
+    "test": "node --test --require ts-node/register ./tests/test_*.ts",
     "doc": "echo nothing",
     "format": "prettier --write '{src,tests,samples}/**/*.ts'"
   },

--- a/packages/lite/tsconfig.json
+++ b/packages/lite/tsconfig.json
@@ -3,10 +3,7 @@
   "compilerOptions": {
     "baseUrl": "./",
     "rootDir": "./src/",
-    "outDir": "./lib",
-    "paths": {
-      "@/*": ["./src/*"]
-    }
+    "outDir": "./lib"
   },
   "include": ["src"]
 }

--- a/packages/samples/package.json
+++ b/packages/samples/package.json
@@ -13,8 +13,8 @@
     "format": "prettier --write 'src/**/*.ts' graph_data/**/*.{json,yaml} htmlSample/*.html",
     "b": "yarn run format && yarn run eslint && yarn run build",
     "doc": "yarn run sample src/toYamlSample.ts",
-    "samples": "npx ts-node  -r tsconfig-paths/register src/sample_runner.ts",
-    "sample": "npx ts-node  -r tsconfig-paths/register"
+    "samples": "npx ts-node src/sample_runner.ts",
+    "sample": "npx ts-node"
   },
   "repository": {
     "type": "git",

--- a/packages/samples/tsconfig.json
+++ b/packages/samples/tsconfig.json
@@ -3,10 +3,7 @@
   "compilerOptions": {
     "baseUrl": "./",                                  /* Specify the base directory to resolve non-relative module names. */
     "rootDir": "./src/",
-    "outDir": "./lib",
-    "paths": {
-       "@/*": ["./src/*"]
-    }
+    "outDir": "./lib"
   },
   "include": ["src"]
 }

--- a/packages/test_utils/package.json
+++ b/packages/test_utils/package.json
@@ -7,7 +7,7 @@
     "./lib"
   ],
   "scripts": {
-    "build": "rm -r lib/* && tsc && tsc-alias",
+    "build": "rm -r lib/* && tsc",
     "eslint": "eslint",
     "test": "echo hello",
     "doc": "echo nothing",

--- a/packages/test_utils/tsconfig.json
+++ b/packages/test_utils/tsconfig.json
@@ -3,10 +3,7 @@
   "compilerOptions": {
     "baseUrl": "./",
     "rootDir": "./src/",
-    "outDir": "./lib",
-    "paths": {
-      "@/*": ["./src/*"]
-    }
+    "outDir": "./lib"
   },
   "include": ["src"]
 }


### PR DESCRIPTION
## Summary
- drop `@` path mapping from each package's `tsconfig.json`
- remove `tsconfig-paths/register` usage from scripts
- stop running `tsc-alias`
- update tests to use relative imports

## Testing
- `yarn test` *(fails: package not in lockfile)*
- `npm test` *(fails: Unknown Syntax Error: Command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686741927cf08333899c402e26c026be