### PR TITLE
Fix path alias in data_agents package

### DIFF
--- a/agents/data_agents/package.json
+++ b/agents/data_agents/package.json
@@ -7,11 +7,11 @@
     "./lib"
   ],
   "scripts": {
-    "build": "rm -r lib/* && tsc && tsc-alias",
+    "build": "rm -r lib/* && tsc",
     "doc": "npx agentdoc",
     "eslint": "eslint",
     "format": "prettier --write '{src,tests,samples}/**/*.ts'",
-    "test": "node --test  -r tsconfig-paths/register --require ts-node/register ./tests/test_*.ts",
+    "test": "node --test --require ts-node/register ./tests/test_*.ts",
     "b": "yarn run format && yarn run eslint && yarn run build"
   },
   "repository": {

--- a/agents/data_agents/tests/test_agent_runner.ts
+++ b/agents/data_agents/tests/test_agent_runner.ts
@@ -1,4 +1,4 @@
-import * as packages from "@/index";
+import * as packages from "../src/index";
 import { agentTestRunner } from "@receptron/test_utils";
 
 const main = async () => {

--- a/agents/data_agents/tsconfig.json
+++ b/agents/data_agents/tsconfig.json
@@ -3,10 +3,7 @@
   "compilerOptions": {
     "baseUrl": "./",
     "rootDir": "./src/",
-    "outDir": "./lib",
-    "paths": {
-      "@/*": ["./src/*"]
-    }
+    "outDir": "./lib"
   },
   "include": ["src"]
 }


### PR DESCRIPTION
## Summary
- remove `@/*` path alias from `data_agents`
- use relative import in data_agents tests
- drop `tsc-alias` and `tsconfig-paths/register` usage in data_agents scripts

## Testing
- `yarn test` *(fails: This package doesn't seem to be present in your lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_686741a30aa483338ec239d0e4c76dba