### PR TITLE
Remove path aliases from agents

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -24,7 +24,7 @@ jobs:
         cache: 'npm'
     - run: yarn install
     - run: yarn run build
-    - run: cd packages/agent_filters/ && npx ts-node -r tsconfig-paths/register tests/express/server.ts &
+    - run: cd packages/agent_filters/ && npx ts-node tests/express/server.ts &
     - run: cd packages/graphai/ && npx http-server tests/http-server/docs  &
     - run: yarn run test 
     - run: cd packages/agents/ && yarn http_test

--- a/agents/agent_utils/package.json
+++ b/agents/agent_utils/package.json
@@ -21,7 +21,7 @@
     "eslint": "eslint",
     "format": "prettier --write '{src,tests,samples}/**/*.ts'",
     "doc": "echo nothing",
-    "test": "node --test  -r tsconfig-paths/register --require ts-node/register ./tests/test_*.ts",
+    "test": "node --test --require ts-node/register ./tests/test_*.ts",
     "b": "yarn run format && yarn run eslint && yarn run build"
   },
   "repository": {

--- a/agents/agent_utils/tests/test_graph.ts
+++ b/agents/agent_utils/tests/test_graph.ts
@@ -2,7 +2,7 @@ import * as vanilla_agent from "@graphai/vanilla";
 
 import { GraphAI } from "graphai";
 
-import { sample2GraphData } from "@/index";
+import { sample2GraphData } from "../src/index";
 
 import test from "node:test";
 import assert from "node:assert";

--- a/agents/agent_utils/tsconfig.json
+++ b/agents/agent_utils/tsconfig.json
@@ -1,12 +1,8 @@
 {
   "extends": "../../config/tsconfig.base.json",
   "compilerOptions": {
-    "baseUrl": "./",
     "rootDir": "./src/",
-    "outDir": "./lib",
-    "paths": {
-      "@/*": ["./src/*"]
-    }
+    "outDir": "./lib"
   },
   "include": ["src"]
 }

--- a/agents/llm_agents/package.json
+++ b/agents/llm_agents/package.json
@@ -7,14 +7,14 @@
     "./lib"
   ],
   "scripts": {
-    "build": "rm -r lib/* && tsc && tsc-alias",
+    "build": "rm -r lib/* && tsc",
     "eslint": "eslint",
     "format": "prettier --write '{src,tests,samples}/**/*.ts'",
     "doc": "npx agentdoc",
     "test": "echo nothing",
     "b": "yarn run format && yarn run eslint && yarn run build",
-    "samples": "npx ts-node  -r tsconfig-paths/register samples/sample_runner.ts",
-    "sample": "npx ts-node  -r tsconfig-paths/register"
+    "samples": "npx ts-node samples/sample_runner.ts",
+    "sample": "npx ts-node"
   },
   "repository": {
     "type": "git",

--- a/agents/llm_agents/tsconfig.json
+++ b/agents/llm_agents/tsconfig.json
@@ -1,12 +1,8 @@
 {
   "extends": "../../config/tsconfig.base.json",
   "compilerOptions": {
-    "baseUrl": "./",
     "rootDir": "./src/",
-    "outDir": "./lib",
-    "paths": {
-      "@/*": ["./src/*"]
-    }
+    "outDir": "./lib"
   },
   "include": ["src"]
 }

--- a/agents/service_agents/package.json
+++ b/agents/service_agents/package.json
@@ -7,12 +7,12 @@
     "./lib"
   ],
   "scripts": {
-    "build": "rm -r lib/* && tsc && tsc-alias",
+    "build": "rm -r lib/* && tsc",
     "eslint": "eslint",
     "doc": "npm run examplesDoc && npx agentdoc",
-    "examplesDoc": "npx ts-node  -r tsconfig-paths/register tests/examples.ts",
+    "examplesDoc": "npx ts-node tests/examples.ts",
     "format": "prettier --write '{src,tests,samples}/**/*.ts'",
-    "test": "node --test  -r tsconfig-paths/register --require ts-node/register ./tests/test_*.ts",
+    "test": "node --test --require ts-node/register ./tests/test_*.ts",
     "b": "yarn run format && yarn run eslint && yarn run build"
   },
   "repository": {

--- a/agents/service_agents/tests/test_agent_runner.ts
+++ b/agents/service_agents/tests/test_agent_runner.ts
@@ -1,4 +1,4 @@
-import { fetchAgent } from "@/index";
+import { fetchAgent } from "../src/index";
 import { agentTestRunner } from "@receptron/test_utils";
 
 const main = async () => {

--- a/agents/service_agents/tests/test_fetch_agent.ts
+++ b/agents/service_agents/tests/test_fetch_agent.ts
@@ -1,5 +1,5 @@
 import { graphDataTestRunner } from "@receptron/test_utils";
-import { fetchAgent } from "@/index";
+import { fetchAgent } from "../src/index";
 import { propertyFilterAgent, copyAgent } from "@graphai/vanilla";
 
 import { graphDataFetch, graphDataPost } from "./graphData";

--- a/agents/service_agents/tsconfig.json
+++ b/agents/service_agents/tsconfig.json
@@ -1,12 +1,8 @@
 {
   "extends": "../../config/tsconfig.base.json",
   "compilerOptions": {
-    "baseUrl": "./",
     "rootDir": "./src/",
-    "outDir": "./lib",
-    "paths": {
-      "@/*": ["./src/*"]
-    }
+    "outDir": "./lib"
   },
   "include": ["src"]
 }

--- a/agents/sleeper_agents/package.json
+++ b/agents/sleeper_agents/package.json
@@ -7,11 +7,11 @@
     "./lib"
   ],
   "scripts": {
-    "build": "rm -r lib/* && tsc && tsc-alias",
+    "build": "rm -r lib/* && tsc",
     "doc": "npx agentdoc",
     "eslint": "eslint",
     "format": "prettier --write '{src,tests,samples}/**/*.ts'",
-    "test": "node --test  -r tsconfig-paths/register --require ts-node/register ./tests/test_*.ts",
+    "test": "node --test --require ts-node/register ./tests/test_*.ts",
     "b": "yarn run format && yarn run eslint && yarn run build"
   },
   "repository": {

--- a/agents/sleeper_agents/tests/test_agent_runner.ts
+++ b/agents/sleeper_agents/tests/test_agent_runner.ts
@@ -1,4 +1,4 @@
-import * as packages from "@/index";
+import * as packages from "../src/index";
 import { agentTestRunner } from "@receptron/test_utils";
 
 const main = async () => {

--- a/agents/sleeper_agents/tsconfig.json
+++ b/agents/sleeper_agents/tsconfig.json
@@ -1,12 +1,8 @@
 {
   "extends": "../../config/tsconfig.base.json",
   "compilerOptions": {
-    "baseUrl": "./",
     "rootDir": "./src/",
-    "outDir": "./lib",
-    "paths": {
-      "@/*": ["./src/*"]
-    }
+    "outDir": "./lib"
   },
   "include": ["src"]
 }

--- a/agents/vanilla_agents/package.json
+++ b/agents/vanilla_agents/package.json
@@ -9,16 +9,16 @@
     "./lib"
   ],
   "scripts": {
-    "build": "rm -r lib/* && tsc && npx rollup -c && tsc-alias",
+    "build": "rm -r lib/* && tsc && npx rollup -c",
     "eslint": "eslint",
     "doc": "npm run examplesDoc && npx agentdoc",
-    "examplesDoc": "npx ts-node  -r tsconfig-paths/register tests/graph/examples.ts",
+    "examplesDoc": "npx ts-node tests/graph/examples.ts",
     "format": "prettier --write '{src,tests,samples}/**/*.ts' *.mjs",
-    "test": "node --test  -r tsconfig-paths/register --require ts-node/register ./tests/**/test_*.ts",
-    "http_test": "node --test  -r tsconfig-paths/register --require ts-node/register ./tests/**/http_*.ts",
+    "test": "node --test --require ts-node/register ./tests/**/test_*.ts",
+    "http_test": "node --test --require ts-node/register ./tests/**/http_*.ts",
     "b": "yarn run format && yarn run eslint && yarn run build",
-    "samples": "npx ts-node  -r tsconfig-paths/register samples/sample_runner.ts",
-    "sample": "npx ts-node  -r tsconfig-paths/register"
+    "samples": "npx ts-node samples/sample_runner.ts",
+    "sample": "npx ts-node"
   },
   "repository": {
     "type": "git",

--- a/agents/vanilla_agents/src/string_agents/string_update_text_agent.ts
+++ b/agents/vanilla_agents/src/string_agents/string_update_text_agent.ts
@@ -1,4 +1,4 @@
-import { nestedAgentGenerator } from "@/generator";
+import { nestedAgentGenerator } from "../generator";
 import { graphDataLatestVersion, AgentFunctionInfo } from "graphai";
 
 const stringUpdateTextGraph = {

--- a/agents/vanilla_agents/tests/agents/run_agent.ts
+++ b/agents/vanilla_agents/tests/agents/run_agent.ts
@@ -2,7 +2,7 @@
 //   yarn run sample tests/agents/run_agent.ts
 
 import "dotenv/config";
-import * as packages from "@/index";
+import * as packages from "../../src/index";
 import { defaultTestContext } from "graphai";
 
 const main = async () => {

--- a/agents/vanilla_agents/tests/agents/test_agent_error.ts
+++ b/agents/vanilla_agents/tests/agents/test_agent_error.ts
@@ -1,4 +1,4 @@
-import { popAgent, pushAgent } from "@/index";
+import { popAgent, pushAgent } from "../../src/index";
 import { defaultTestContext } from "graphai";
 
 import test from "node:test";

--- a/agents/vanilla_agents/tests/agents/test_agent_runner.ts
+++ b/agents/vanilla_agents/tests/agents/test_agent_runner.ts
@@ -1,4 +1,4 @@
-import * as packages from "@/index";
+import * as packages from "../../src/index";
 import { agentTestRunner } from "@receptron/test_utils";
 
 const main = async () => {

--- a/agents/vanilla_agents/tests/agents/test_array_agent_error.ts
+++ b/agents/vanilla_agents/tests/agents/test_array_agent_error.ts
@@ -1,4 +1,4 @@
-import { popAgent, pushAgent } from "@/index";
+import { popAgent, pushAgent } from "../../src/index";
 import { defaultTestContext } from "graphai";
 
 import test from "node:test";

--- a/agents/vanilla_agents/tests/agents/test_map_agent.ts
+++ b/agents/vanilla_agents/tests/agents/test_map_agent.ts
@@ -1,4 +1,4 @@
-import { mapAgent, stringTemplateAgent, copyAgent } from "@/index";
+import { mapAgent, stringTemplateAgent, copyAgent } from "../../src/index";
 import { defaultTestContext } from "graphai";
 
 import test from "node:test";

--- a/agents/vanilla_agents/tests/agents/test_nest_agent.ts
+++ b/agents/vanilla_agents/tests/agents/test_nest_agent.ts
@@ -1,5 +1,5 @@
-import { nestedAgent, copyAgent } from "@/index";
-import { nestedAgentGenerator } from "@/generator";
+import { nestedAgent, copyAgent } from "../../src/index";
+import { nestedAgentGenerator } from "../../src/generator";
 
 import { sleepAndMergeAgent } from "@graphai/sleeper_agents";
 import { defaultTestContext, graphDataLatestVersion, agentInfoWrapper } from "graphai";

--- a/agents/vanilla_agents/tests/graph/test_dynamic_graph.ts
+++ b/agents/vanilla_agents/tests/graph/test_dynamic_graph.ts
@@ -1,5 +1,5 @@
 import { graphDataTestRunner } from "@receptron/test_utils";
-import * as agents from "@/index";
+import * as agents from "../../src/index";
 import { sleepAndMergeAgent } from "@graphai/sleeper_agents";
 
 import { dynamicGraphData, dynamicGraphData2, dynamicGraphData3 } from "./graphData";

--- a/agents/vanilla_agents/tests/graph/test_fork.ts
+++ b/agents/vanilla_agents/tests/graph/test_fork.ts
@@ -1,6 +1,6 @@
 import { AgentFunction, agentInfoWrapper } from "graphai";
 import { graphDataTestRunner } from "@receptron/test_utils";
-import * as vanilla_agents from "@/index";
+import * as vanilla_agents from "../../src/index";
 import { sleepAndMergeAgent } from "@graphai/sleeper_agents";
 const agents = {
   sleepAndMergeAgent,

--- a/agents/vanilla_agents/tests/graph/test_loop_nested_array.ts
+++ b/agents/vanilla_agents/tests/graph/test_loop_nested_array.ts
@@ -1,5 +1,5 @@
 import { graphDataTestRunner, fileBaseName } from "@receptron/test_utils";
-import * as vanilla_agents from "@/index";
+import * as vanilla_agents from "../../src/index";
 import { sleepAndMergeAgent } from "@graphai/sleeper_agents";
 const agents = {
   sleepAndMergeAgent,

--- a/agents/vanilla_agents/tests/graph/test_loop_push.ts
+++ b/agents/vanilla_agents/tests/graph/test_loop_push.ts
@@ -1,5 +1,5 @@
 import { graphDataTestRunner, fileBaseName } from "@receptron/test_utils";
-import * as vanilla_agents from "@/index";
+import * as vanilla_agents from "../../src/index";
 import { sleepAndMergeAgent } from "@graphai/sleeper_agents";
 const agents = {
   sleepAndMergeAgent,

--- a/agents/vanilla_agents/tests/graph/test_map.ts
+++ b/agents/vanilla_agents/tests/graph/test_map.ts
@@ -1,5 +1,5 @@
 import { graphDataTestRunner } from "@receptron/test_utils";
-import * as vanilla_agents from "@/index";
+import * as vanilla_agents from "../../src/index";
 import { sleepAndMergeAgent } from "@graphai/sleeper_agents";
 const agents = {
   sleepAndMergeAgent,

--- a/agents/vanilla_agents/tests/graph/test_nest_agent_abort.ts
+++ b/agents/vanilla_agents/tests/graph/test_nest_agent_abort.ts
@@ -1,5 +1,5 @@
 import { GraphAI, GraphData, sleep, NodeState, graphDataLatestVersion, AgentFilterFunction } from "graphai";
-import * as agents from "@/index";
+import * as agents from "../../src/index";
 
 import test from "node:test";
 import assert from "node:assert";

--- a/agents/vanilla_agents/tsconfig.json
+++ b/agents/vanilla_agents/tsconfig.json
@@ -1,12 +1,8 @@
 {
   "extends": "../../config/tsconfig.base.json",
   "compilerOptions": {
-    "baseUrl": "./",
     "rootDir": "./src/",
-    "outDir": "./lib",
-    "paths": {
-      "@/*": ["./src/*"]
-    }
+    "outDir": "./lib"
   },
   "include": ["src"]
 }

--- a/agents/vanilla_node_agents/package.json
+++ b/agents/vanilla_node_agents/package.json
@@ -7,15 +7,15 @@
     "./lib"
   ],
   "scripts": {
-    "build": "rm -r lib/* && tsc && tsc-alias",
+    "build": "rm -r lib/* && tsc",
     "eslint": "eslint",
     "doc": "npx agentdoc",
     "format": "prettier --write '{src,tests,samples}/**/*.ts' *.mjs",
-    "test": "node --test  -r tsconfig-paths/register --require ts-node/register ./tests/**/test_*.ts",
-    "http_test": "node --test  -r tsconfig-paths/register --require ts-node/register ./tests/**/http_*.ts",
+    "test": "node --test --require ts-node/register ./tests/**/test_*.ts",
+    "http_test": "node --test --require ts-node/register ./tests/**/http_*.ts",
     "b": "yarn run format && yarn run eslint && yarn run build",
-    "samples": "npx ts-node  -r tsconfig-paths/register samples/sample_runner.ts",
-    "sample": "npx ts-node  -r tsconfig-paths/register"
+    "samples": "npx ts-node samples/sample_runner.ts",
+    "sample": "npx ts-node"
   },
   "repository": {
     "type": "git",

--- a/agents/vanilla_node_agents/tests/agents/test_agent_runner.ts
+++ b/agents/vanilla_node_agents/tests/agents/test_agent_runner.ts
@@ -1,4 +1,4 @@
-import * as packages from "@/index";
+import * as packages from "../../src/index";
 import { agentTestRunner } from "@receptron/test_utils";
 
 const main = async () => {

--- a/agents/vanilla_node_agents/tests/agents/test_stream.ts
+++ b/agents/vanilla_node_agents/tests/agents/test_stream.ts
@@ -1,5 +1,5 @@
 import { NodeState } from "graphai";
-import { fileReadAgent } from "@/index";
+import { fileReadAgent } from "../../src/index";
 
 const main = async () => {
   const res = await fileReadAgent.agent({

--- a/agents/vanilla_node_agents/tsconfig.json
+++ b/agents/vanilla_node_agents/tsconfig.json
@@ -1,12 +1,8 @@
 {
   "extends": "../../config/tsconfig.base.json",
   "compilerOptions": {
-    "baseUrl": "./",
     "rootDir": "./src/",
-    "outDir": "./lib",
-    "paths": {
-      "@/*": ["./src/*"]
-    }
+    "outDir": "./lib"
   },
   "include": ["src"]
 }

--- a/package.json
+++ b/package.json
@@ -26,8 +26,6 @@
     "prettier": "^3.6.2",
     "rollup": "^4.44.1",
     "ts-node": "^10.9.2",
-    "tsc-alias": "^1.8.16",
-    "tsconfig-paths": "^4.2.0",
     "tslib": "^2.8.1",
     "typescript": "^5.8.3",
     "typescript-eslint": "^8.35.1"

--- a/packages/agent_filters/tests/express/run_client.ts
+++ b/packages/agent_filters/tests/express/run_client.ts
@@ -1,7 +1,7 @@
 // run server:
 //     yarn run http_server
 // run test:
-//     npx ts-node -r tsconfig-paths/register tests/express/run_client.ts
+//     npx ts-node tests/express/run_client.ts
 //
 
 import { httpAgentFilter } from "../../src/index";

--- a/yarn.lock
+++ b/yarn.lock
@@ -3674,27 +3674,6 @@ ts-node@^10.9.2:
     v8-compile-cache-lib "^3.0.1"
     yn "3.1.1"
 
-tsc-alias@^1.8.16:
-  version "1.8.16"
-  resolved "https://registry.npmjs.org/tsc-alias/-/tsc-alias-1.8.16.tgz"
-  integrity sha512-QjCyu55NFyRSBAl6+MTFwplpFcnm2Pq01rR/uxfqJoLMm6X3O14KEGtaSDZpJYaE1bJBGDjD0eSuiIWPe2T58g==
-  dependencies:
-    chokidar "^3.5.3"
-    commander "^9.0.0"
-    get-tsconfig "^4.10.0"
-    globby "^11.0.4"
-    mylas "^2.1.9"
-    normalize-path "^3.0.0"
-    plimit-lit "^1.2.6"
-
-tsconfig-paths@^4.2.0:
-  version "4.2.0"
-  resolved "https://registry.yarnpkg.com/tsconfig-paths/-/tsconfig-paths-4.2.0.tgz#ef78e19039133446d244beac0fd6a1632e2d107c"
-  integrity sha512-NoZ4roiN7LnbKn9QqE1amc9DJfzvZXxF4xDavcOWt1BPkdx+m+0gJuPM+S0vCe7zTJMYUP0R8pO2XMr+Y8oLIg==
-  dependencies:
-    json5 "^2.2.2"
-    minimist "^1.2.6"
-    strip-bom "^3.0.0"
 
 tslib@^2.8.1:
   version "2.8.1"


### PR DESCRIPTION
## Summary
- update imports in agents packages to use relative paths
- remove `@/*` paths from agents tsconfig files
- drop `tsc-alias` and `tsconfig-paths` usage from package.json files
- clean `yarn.lock`

## Testing
- `yarn test` *(fails: package not present in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_686746f9a8c48333b25eebc0ae75743b