### PR TITLE
Remove stale samples references

### DIFF
--- a/agent_filters/cache_agent_filter/package.json
+++ b/agent_filters/cache_agent_filter/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "build": "rm -r lib/* && tsc",
     "eslint": "eslint",
-    "format": "prettier --write '{src,tests,samples}/**/*.ts'",
+    "format": "prettier --write '{src,tests}/**/*.ts'",
     "test": "node --test --require ts-node/register ./tests/test_*.ts",
     "doc": "echo nothing",
     "b": "yarn run format && yarn run eslint && yarn run build"

--- a/agent_filters/http_client_agent_filter/package.json
+++ b/agent_filters/http_client_agent_filter/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "build": "rm -r lib/* && tsc",
     "eslint": "eslint",
-    "format": "prettier --write '{src,tests,samples}/**/*.ts'",
+    "format": "prettier --write '{src,tests}/**/*.ts'",
     "test": "echo nothing",
     "doc": "echo nothing",
     "b": "yarn run format && yarn run eslint && yarn run build"

--- a/agent_filters/namedinput_validator_agent_filter/package.json
+++ b/agent_filters/namedinput_validator_agent_filter/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "build": "rm -r lib/* && tsc",
     "eslint": "eslint",
-    "format": "prettier --write '{src,tests,samples}/**/*.ts'",
+    "format": "prettier --write '{src,tests}/**/*.ts'",
     "test": "node --test --require ts-node/register ./tests/test_*.ts",
     "doc": "echo nothing",
     "b": "yarn run format && yarn run eslint && yarn run build"

--- a/agent_filters/step_runner_agent_filter/package.json
+++ b/agent_filters/step_runner_agent_filter/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "build": "rm -r lib/* && tsc",
     "eslint": "eslint",
-    "format": "prettier --write '{src,tests,samples}/**/*.ts'",
+    "format": "prettier --write '{src,tests}/**/*.ts'",
     "test": "echo nothing",
     "test_run": "npx ts-node tests/run_step_runner.ts",
     "doc": "echo nothing",

--- a/agent_filters/stream_agent_filter/package.json
+++ b/agent_filters/stream_agent_filter/package.json
@@ -31,7 +31,7 @@
   "scripts": {
     "build": "rm -r lib/* && tsc",
     "eslint": "eslint",
-    "format": "prettier --write '{src,tests,samples}/**/*.ts'",
+    "format": "prettier --write '{src,tests}/**/*.ts'",
     "test": "node --test  --require ts-node/register ./tests/test_*.ts",
     "doc": "echo nothing",
     "b": "yarn run format && yarn run eslint && yarn run build"

--- a/agent_filters/utils/package.json
+++ b/agent_filters/utils/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "build": "rm -r lib/* && tsc",
     "eslint": "eslint",
-    "format": "prettier --write '{src,tests,samples}/**/*.ts'",
+    "format": "prettier --write '{src,tests}/**/*.ts'",
     "test": "node --test --require ts-node/register ./tests/test_*.ts",
     "doc": "echo nothing",
     "b": "yarn run format && yarn run eslint && yarn run build"

--- a/agents/agent_utils/package.json
+++ b/agents/agent_utils/package.json
@@ -19,7 +19,7 @@
   "scripts": {
     "build": "rm -r lib/* && tsc && npx rollup -c",
     "eslint": "eslint",
-    "format": "prettier --write '{src,tests,samples}/**/*.ts'",
+    "format": "prettier --write '{src,tests}/**/*.ts'",
     "doc": "echo nothing",
     "test": "node --test --require ts-node/register ./tests/test_*.ts",
     "b": "yarn run format && yarn run eslint && yarn run build"

--- a/agents/data_agents/package.json
+++ b/agents/data_agents/package.json
@@ -10,7 +10,7 @@
     "build": "rm -r lib/* && tsc",
     "doc": "npx agentdoc",
     "eslint": "eslint",
-    "format": "prettier --write '{src,tests,samples}/**/*.ts'",
+    "format": "prettier --write '{src,tests}/**/*.ts'",
     "test": "node --test --require ts-node/register ./tests/test_*.ts",
     "b": "yarn run format && yarn run eslint && yarn run build"
   },

--- a/agents/input_agents/package.json
+++ b/agents/input_agents/package.json
@@ -10,7 +10,7 @@
     "build": "rm -r lib/* && tsc",
     "eslint": "eslint",
     "doc": "npx agentdoc",
-    "format": "prettier --write '{src,tests,samples}/**/*.ts'",
+    "format": "prettier --write '{src,tests}/**/*.ts'",
     "test": "echo nothing",
     "test_run": "node --require ts-node/register ./test/run_agent.ts",
     "b": "yarn run format && yarn run eslint && yarn run build"

--- a/agents/llm_agents/package.json
+++ b/agents/llm_agents/package.json
@@ -9,11 +9,10 @@
   "scripts": {
     "build": "rm -r lib/* && tsc",
     "eslint": "eslint",
-    "format": "prettier --write '{src,tests,samples}/**/*.ts'",
+    "format": "prettier --write '{src,tests}/**/*.ts'",
     "doc": "npx agentdoc",
     "test": "echo nothing",
     "b": "yarn run format && yarn run eslint && yarn run build",
-    "samples": "npx ts-node samples/sample_runner.ts",
     "sample": "npx ts-node"
   },
   "repository": {

--- a/agents/service_agents/package.json
+++ b/agents/service_agents/package.json
@@ -11,7 +11,7 @@
     "eslint": "eslint",
     "doc": "npm run examplesDoc && npx agentdoc",
     "examplesDoc": "npx ts-node tests/examples.ts",
-    "format": "prettier --write '{src,tests,samples}/**/*.ts'",
+    "format": "prettier --write '{src,tests}/**/*.ts'",
     "test": "node --test --require ts-node/register ./tests/test_*.ts",
     "b": "yarn run format && yarn run eslint && yarn run build"
   },

--- a/agents/sleeper_agents/package.json
+++ b/agents/sleeper_agents/package.json
@@ -10,7 +10,7 @@
     "build": "rm -r lib/* && tsc",
     "doc": "npx agentdoc",
     "eslint": "eslint",
-    "format": "prettier --write '{src,tests,samples}/**/*.ts'",
+    "format": "prettier --write '{src,tests}/**/*.ts'",
     "test": "node --test --require ts-node/register ./tests/test_*.ts",
     "b": "yarn run format && yarn run eslint && yarn run build"
   },

--- a/agents/vanilla_agents/package.json
+++ b/agents/vanilla_agents/package.json
@@ -13,11 +13,10 @@
     "eslint": "eslint",
     "doc": "npm run examplesDoc && npx agentdoc",
     "examplesDoc": "npx ts-node tests/graph/examples.ts",
-    "format": "prettier --write '{src,tests,samples}/**/*.ts' *.mjs",
+    "format": "prettier --write '{src,tests}/**/*.ts' *.mjs",
     "test": "node --test --require ts-node/register ./tests/**/test_*.ts",
     "http_test": "node --test --require ts-node/register ./tests/**/http_*.ts",
     "b": "yarn run format && yarn run eslint && yarn run build",
-    "samples": "npx ts-node samples/sample_runner.ts",
     "sample": "npx ts-node"
   },
   "repository": {

--- a/agents/vanilla_node_agents/package.json
+++ b/agents/vanilla_node_agents/package.json
@@ -10,11 +10,10 @@
     "build": "rm -r lib/* && tsc",
     "eslint": "eslint",
     "doc": "npx agentdoc",
-    "format": "prettier --write '{src,tests,samples}/**/*.ts' *.mjs",
+    "format": "prettier --write '{src,tests}/**/*.ts' *.mjs",
     "test": "node --test --require ts-node/register ./tests/**/test_*.ts",
     "http_test": "node --test --require ts-node/register ./tests/**/http_*.ts",
     "b": "yarn run format && yarn run eslint && yarn run build",
-    "samples": "npx ts-node samples/sample_runner.ts",
     "sample": "npx ts-node"
   },
   "repository": {

--- a/llm_agents/anthropic_agent/package.json
+++ b/llm_agents/anthropic_agent/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "build": "rm -r lib/* && tsc",
     "eslint": "eslint",
-    "format": "prettier --write '{src,tests,samples}/**/*.ts'",
+    "format": "prettier --write '{src,tests}/**/*.ts'",
     "doc": "npm run examplesDoc && npx agentdoc",
     "examplesDoc": "npx ts-node  tests/examples.ts",
     "test": "echo hello",

--- a/llm_agents/gemini_agent/package.json
+++ b/llm_agents/gemini_agent/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "build": "rm -r lib/* && tsc",
     "eslint": "eslint",
-    "format": "prettier --write '{src,tests,samples}/**/*.ts'",
+    "format": "prettier --write '{src,tests}/**/*.ts'",
     "doc": "npm run examplesDoc && npx agentdoc",
     "examplesDoc": "npx ts-node  tests/examples.ts",
     "test": "echo hello",

--- a/llm_agents/groq_agent/package.json
+++ b/llm_agents/groq_agent/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "build": "rm -r lib/* && tsc",
     "eslint": "eslint",
-    "format": "prettier --write '{src,tests,samples}/**/*.ts'",
+    "format": "prettier --write '{src,tests}/**/*.ts'",
     "doc": "npm run examplesDoc && npx agentdoc",
     "examplesDoc": "npx ts-node  tests/examples.ts",
     "test": "echo hello",

--- a/llm_agents/llm_utils/package.json
+++ b/llm_agents/llm_utils/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "build": "rm -r lib/* && tsc",
     "eslint": "eslint",
-    "format": "prettier --write '{src,tests,samples}/**/*.ts'",
+    "format": "prettier --write '{src,tests}/**/*.ts'",
     "doc": "echo nothing",
     "test": "node --test  --require ts-node/register ./tests/test_*.ts",
     "b": "yarn run format && yarn run eslint && yarn run build"

--- a/llm_agents/openai_agent/package.json
+++ b/llm_agents/openai_agent/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "build": "rm -r lib/* && tsc",
     "eslint": "eslint",
-    "format": "prettier --write '{src,tests,samples}/**/*.ts'",
+    "format": "prettier --write '{src,tests}/**/*.ts'",
     "doc": "npm run examplesDoc && npx agentdoc",
     "examplesDoc": "npx ts-node  tests/examples.ts",
     "test": "echo nothing",

--- a/llm_agents/openai_fetch_agent/package.json
+++ b/llm_agents/openai_fetch_agent/package.json
@@ -11,7 +11,7 @@
   "scripts": {
     "build": "rm -r lib/* && tsc && npx rollup -c",
     "eslint": "eslint",
-    "format": "prettier --write '{src,tests,samples}/**/*.ts'",
+    "format": "prettier --write '{src,tests}/**/*.ts'",
     "doc": "npm run examplesDoc && npx agentdoc",
     "examplesDoc": "npx ts-node  tests/examples.ts",
     "test": "echo nothing",

--- a/llm_agents/replicate_agent/package.json
+++ b/llm_agents/replicate_agent/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "build": "rm -r lib/* && tsc",
     "eslint": "eslint",
-    "format": "prettier --write '{src,tests,samples}/**/*.ts'",
+    "format": "prettier --write '{src,tests}/**/*.ts'",
     "doc": "npm run examplesDoc && npx agentdoc",
     "examplesDoc": "npx ts-node  tests/examples.ts",
     "test": "echo nothing",

--- a/llm_agents/slashgpt_agent/package.json
+++ b/llm_agents/slashgpt_agent/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "build": "rm -r lib/* && tsc",
     "eslint": "eslint",
-    "format": "prettier --write '{src,tests,samples}/**/*.ts'",
+    "format": "prettier --write '{src,tests}/**/*.ts'",
     "doc": "npx agentdoc",
     "test": "echo hello",
     "test_run": "node --test  --require ts-node/register ./tests/run_*.ts # just run locally",

--- a/llm_agents/token_bound_string_agent/package.json
+++ b/llm_agents/token_bound_string_agent/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "build": "rm -r lib/* && tsc",
     "eslint": "eslint",
-    "format": "prettier --write '{src,tests,samples}/**/*.ts'",
+    "format": "prettier --write '{src,tests}/**/*.ts'",
     "doc": "npx agentdoc",
     "test": "node --test  --require ts-node/register ./tests/test_*.ts",
     "b": "yarn run format && yarn run eslint && yarn run build"

--- a/llm_agents/tools_agent/package.json
+++ b/llm_agents/tools_agent/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "build": "rm -r lib/* && tsc",
     "eslint": "eslint",
-    "format": "prettier --write '{src,tests,samples}/**/*.ts'",
+    "format": "prettier --write '{src,tests}/**/*.ts'",
     "doc": "npx agentdoc",
     "examplesDoc": "npx ts-node  tests/examples.ts",
     "test": "echo nothing",

--- a/packages/agent_filters/package.json
+++ b/packages/agent_filters/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "build": "rm -r lib/* && tsc",
     "eslint": "eslint",
-    "format": "prettier --write '{src,tests,samples}/**/*.ts'",
+    "format": "prettier --write '{src,tests}/**/*.ts'",
     "test": "echo nothing",
     "doc": "echo nothing",
     "http_server": "npx ts-node tests/express/server.ts",

--- a/packages/agentdoc/package.json
+++ b/packages/agentdoc/package.json
@@ -14,7 +14,7 @@
   "scripts": {
     "build": "tsc",
     "eslint": "eslint --fix",
-    "format": "prettier --write '{src,test_yaml,samples}/**/*.{yaml,ts,json}'",
+    "format": "prettier --write '{src,test_yaml}/**/*.{yaml,ts,json}'",
     "doc": "echo nothing",
     "test": "node --test --require ts-node/register ./tests/test_*.ts",
     "b": "yarn run format && yarn run eslint && yarn run build"

--- a/packages/agents/package.json
+++ b/packages/agents/package.json
@@ -11,7 +11,7 @@
     "eslint": "eslint",
     "doc": "npm run examplesDoc && npx agentdoc",
     "examplesDoc": "npx ts-node tests/graphai/examples.ts",
-    "format": "prettier --write '{src,tests,samples}/**/*.ts'",
+    "format": "prettier --write '{src,tests}/**/*.ts'",
     "test": "node --test --require ts-node/register ./tests/**/test_*.ts",
     "http_test": "node --test --require ts-node/register ./tests/**/http_*.ts",
     "b": "yarn run format && yarn run eslint && yarn run build"

--- a/packages/graphai/package.json
+++ b/packages/graphai/package.json
@@ -14,7 +14,7 @@
     "typedoc": "npx typedoc src/index.ts --out ../../docs/apiDoc",
     "typedoc:md": "npx typedoc src/index.ts --out ../../docs/apiDocMd --plugin typedoc-plugin-markdown",
     "doc": "echo nothing",
-    "format": "prettier --write '{src,tests,samples}/**/*.ts' *.mjs",
+    "format": "prettier --write '{src,tests}/**/*.ts' *.mjs",
     "test": "node --test --require ts-node/register ./tests/**/test_*.ts",
     "b": "yarn run format && yarn run eslint && yarn run build"
   },


### PR DESCRIPTION
## Summary
- cleanup `format` and `samples` scripts
- remove `samples` glob from prettier commands

## Testing
- `yarn test` *(fails: This package doesn't seem to be present in your lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_68674de040d08333b10502d7fe1161c3