### PR TITLE
Replace unmaintained json-schema-generator

### DIFF
--- a/packages/agentdoc/lib/mono_doc.js
+++ b/packages/agentdoc/lib/mono_doc.js
@@ -5,7 +5,37 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.generateMonoDoc = exports.readTemplate = void 0;
 const utils_1 = require("graphai/lib/utils/utils");
-const json_schema_generator_1 = __importDefault(require("json-schema-generator"));
+// json-schema-generator was unmaintained, replace with a simple schema generator
+const generateSchema = (value) => {
+    if (Array.isArray(value)) {
+        if (value.length === 0) {
+            return { type: "array" };
+        }
+        return { type: "array", items: generateSchema(value[0]) };
+    }
+    if (value === null) {
+        return { type: "null" };
+    }
+    if (typeof value === "object") {
+        const properties = {};
+        const required = [];
+        for (const key of Object.keys(value)) {
+            properties[key] = generateSchema(value[key]);
+            required.push(key);
+        }
+        return { type: "object", properties, required };
+    }
+    if (typeof value === "string") {
+        return { type: "string" };
+    }
+    if (typeof value === "number") {
+        return { type: "number" };
+    }
+    if (typeof value === "boolean") {
+        return { type: "boolean" };
+    }
+    return { type: "any" };
+};
 const fs_1 = __importDefault(require("fs"));
 const path_1 = __importDefault(require("path"));
 const agentAttribute = (agentInfo, key) => {
@@ -47,7 +77,7 @@ const agentAttribute = (agentInfo, key) => {
         }
         if (agentInfo.samples && agentInfo.samples[0]) {
             const sample = agentInfo.samples[0];
-            return ["#### inputs", "```json", JSON.stringify((0, json_schema_generator_1.default)(sample.inputs), null, 2), "```"].join("\n\n");
+            return ["#### inputs", "```json", JSON.stringify(generateSchema(sample.inputs), null, 2), "```"].join("\n\n");
         }
         return "";
     }

--- a/packages/agentdoc/package.json
+++ b/packages/agentdoc/package.json
@@ -30,10 +30,8 @@
   },
   "homepage": "https://github.com/receptron/graphai#readme",
   "devDependencies": {
-    "@types/json-schema-generator": "^2.0.3"
   },
   "dependencies": {
-    "json-schema-generator": "^2.0.6"
   },
   "types": "./lib/index.d.ts",
   "directories": {

--- a/packages/cli/lib/docs.js
+++ b/packages/cli/lib/docs.js
@@ -5,7 +5,37 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.generateDoc = exports.readTemplate = void 0;
 const utils_1 = require("graphai/lib/utils/utils");
-const json_schema_generator_1 = __importDefault(require("json-schema-generator"));
+// json-schema-generator was unmaintained, replace with a simple schema generator
+const generateSchema = (value) => {
+    if (Array.isArray(value)) {
+        if (value.length === 0) {
+            return { type: "array" };
+        }
+        return { type: "array", items: generateSchema(value[0]) };
+    }
+    if (value === null) {
+        return { type: "null" };
+    }
+    if (typeof value === "object") {
+        const properties = {};
+        const required = [];
+        for (const key of Object.keys(value)) {
+            properties[key] = generateSchema(value[key]);
+            required.push(key);
+        }
+        return { type: "object", properties, required };
+    }
+    if (typeof value === "string") {
+        return { type: "string" };
+    }
+    if (typeof value === "number") {
+        return { type: "number" };
+    }
+    if (typeof value === "boolean") {
+        return { type: "boolean" };
+    }
+    return { type: "any" };
+};
 const fs_1 = __importDefault(require("fs"));
 const path_1 = __importDefault(require("path"));
 const agentAttribute = (agentInfo, key) => {
@@ -47,7 +77,7 @@ const agentAttribute = (agentInfo, key) => {
         }
         if (agentInfo.samples && agentInfo.samples[0]) {
             const sample = agentInfo.samples[0];
-            return ["#### inputs", "```json", JSON.stringify((0, json_schema_generator_1.default)(sample.inputs), null, 2), "````"].join("\n\n");
+            return ["#### inputs", "```json", JSON.stringify(generateSchema(sample.inputs), null, 2), "````"].join("\n\n");
         }
         return "";
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -671,12 +671,6 @@
   resolved "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.4.tgz"
   integrity sha512-D0CFMMtydbJAegzOyHjtiKPLlvnm3iTZyZRSZoLq2mRhDdmLfIWOCYPfQJ4cu2erKghU++QvjcUjp/5h7hESpA==
 
-"@types/json-schema-generator@^2.0.3":
-  version "2.0.3"
-  resolved "https://registry.npmjs.org/@types/json-schema-generator/-/json-schema-generator-2.0.3.tgz"
-  integrity sha512-DxsHiv9zvKa0yMiW4slLrOdsK+Vm/ZgWb5tkMXHuGwF9cbiBS1uHabf0M7lRVXNgLlk3tYLOYNNjSF+GObqU4w==
-  dependencies:
-    "@types/json-schema" "*"
 
 "@types/json-schema@*", "@types/json-schema@^7.0.15":
   version "7.0.15"
@@ -2328,16 +2322,6 @@ json-promise@^1.1.8:
   dependencies:
     bluebird "*"
 
-json-schema-generator@^2.0.6:
-  version "2.0.6"
-  resolved "https://registry.yarnpkg.com/json-schema-generator/-/json-schema-generator-2.0.6.tgz#f6f2bef5c52117f51137a9b7b1c32677239e17ca"
-  integrity sha512-WyWDTK3jnv/OBI43uWw7pTGoDQ62PfccySZCHTBsOfS6D9QhsQr+95Wcwq5lqjzkiDQkTNkWzXEqHOhswfufmw==
-  dependencies:
-    json-promise "^1.1.8"
-    mkdirp "^0.5.0"
-    optimist "^0.6.1"
-    pretty-data "^0.40.0"
-    request "^2.81.0"
 
 json-schema-traverse@^0.4.1:
   version "0.4.1"


### PR DESCRIPTION
## Summary
- drop json-schema-generator dependency from agentdoc
- implement lightweight schema generator
- use the new generator in cli/docs and agentdoc

## Testing
- `yarn test` *(fails: graphai-wrapper@workspace missing from lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_68674e8a3924833399f4401cce0e713c