### PR TITLE
Replace inquirer/prompts with @inquirer/select

### DIFF
--- a/packages/samples/package.json
+++ b/packages/samples/package.json
@@ -27,7 +27,7 @@
   },
   "homepage": "https://github.com/receptron/graphai#readme",
   "devDependencies": {
-    "@inquirer/prompts": "^7.5.3",
+    "@inquirer/select": "^4.2.3",
     "arxiv-api-ts": "^1.0.4",
     "sqlite3": "^5.1.7"
   },

--- a/packages/samples/src/utils/agents/interactiveInputAgent.ts
+++ b/packages/samples/src/utils/agents/interactiveInputAgent.ts
@@ -1,5 +1,5 @@
 import { AgentFunction } from "graphai";
-import { select } from "@inquirer/prompts";
+import select from "@inquirer/select";
 
 export const interactiveInputSelectAgent: AgentFunction<{ resultKey?: string; isReturnString: boolean }, string | { [x: string]: string }> = async ({
   namedInputs,

--- a/yarn.lock
+++ b/yarn.lock
@@ -248,21 +248,6 @@
     "@inquirer/type" "^3.0.7"
     ansi-escapes "^4.3.2"
 
-"@inquirer/prompts@^7.5.3":
-  version "7.5.3"
-  resolved "https://registry.yarnpkg.com/@inquirer/prompts/-/prompts-7.5.3.tgz#2b4c705a79658cf534fc5a5dba780a153f3cd83d"
-  integrity sha512-8YL0WiV7J86hVAxrh3fE5mDCzcTDe1670unmJRz6ArDgN+DBK1a0+rbnNWp4DUB5rPMwqD5ZP6YHl9KK1mbZRg==
-  dependencies:
-    "@inquirer/checkbox" "^4.1.8"
-    "@inquirer/confirm" "^5.1.12"
-    "@inquirer/editor" "^4.2.13"
-    "@inquirer/expand" "^4.0.15"
-    "@inquirer/input" "^4.1.12"
-    "@inquirer/number" "^3.0.15"
-    "@inquirer/password" "^4.0.15"
-    "@inquirer/rawlist" "^4.1.3"
-    "@inquirer/search" "^3.0.15"
-    "@inquirer/select" "^4.2.3"
 
 "@inquirer/rawlist@^4.1.3":
   version "4.1.3"


### PR DESCRIPTION
## Summary
- switch interactive sample agent to use `@inquirer/select`
- remove `@inquirer/prompts` dependency

## Testing
- `yarn test` *(fails: package not present in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_686750950e848333b83956f6205cd6ee