### PR TITLE
Fix JSON parser agent regex

### DIFF
--- a/agents/vanilla_agents/src/string_agents/json_parser_agent.ts
+++ b/agents/vanilla_agents/src/string_agents/json_parser_agent.ts
@@ -9,10 +9,27 @@ export const jsonParserAgent: AgentFunction<null, unknown, GraphAIWithOptionalTe
       text: JSON.stringify(data, null, 2),
     };
   }
-  const match = ("\n" + text).match(/\n```[a-zA-Z]*([\s\S]*?)\n```/);
-  if (match) {
+  const codeBlock = (() => {
+    if (!text) {
+      return undefined;
+    }
+    const start = text.indexOf("\n```");
+    if (start === -1) {
+      return undefined;
+    }
+    const firstNewLine = text.indexOf("\n", start + 4);
+    if (firstNewLine === -1) {
+      return undefined;
+    }
+    const end = text.indexOf("\n```", firstNewLine + 1);
+    if (end === -1) {
+      return undefined;
+    }
+    return text.slice(firstNewLine + 1, end);
+  })();
+  if (codeBlock !== undefined) {
     return {
-      data: JSON.parse(match[1]),
+      data: JSON.parse(codeBlock),
     };
   }
   return {


### PR DESCRIPTION
## Summary
- replace vulnerable regex in `jsonParserAgent` with a linear string search to avoid potential ReDoS attacks

## Testing
- `yarn run format` *(fails: package missing in lockfile)*
- `yarn run test` *(fails: package missing in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_686752f7e9508333982b5f23fe97f1d8