### PR TITLE
Fix Node.js CI workflow permissions

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -6,6 +6,9 @@ name: Node.js CI
 on:
   pull_request
 
+permissions:
+  contents: read
+
 jobs:
   build:
 


### PR DESCRIPTION
## Summary
- add `permissions: contents: read` for Node.js CI workflow

## Testing
- `yarn run test` *(fails: package not in lockfile)*
- `yarn install` *(fails: network access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_686756de83488333b212c4f1b21f69e2