### PR TITLE
Support OpenAI-like response format for geminiAgent

### DIFF
--- a/docs/agentDocs/llm/geminiAgent.md
+++ b/docs/agentDocs/llm/geminiAgent.md
@@ -9,6 +9,8 @@
 
 Gemini Agent
 
+This agent returns results in a format compatible with OpenAI's Chat Completion API.
+
 ## Schema
 
 #### inputs
@@ -36,6 +38,9 @@ Gemini Agent
     "prompt": {
       "type": "string",
       "description": "query string"
+    },
+    "response_format": {
+      "type": "object"
     },
     "messages": {
       "anyOf": [


### PR DESCRIPTION
## Summary
- enhance geminiAgent to parse and return `response_format`
- expose `response_format` input on geminiAgent and set generationConfig accordingly
- update docs for geminiAgent with new behaviour

## Testing
- `yarn test` *(fails: package missing in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_686790fc656c8333ac7217f611a581c0