### PR TITLE
Improve the mermaid output in CLI

### DIFF
--- a/packages/cli/lib/mermaid.d.ts
+++ b/packages/cli/lib/mermaid.d.ts
@@ -1,2 +1,2 @@
-import { GraphData } from "graphai";
+import { type GraphData } from "graphai";
 export declare const mermaid: (graphData: GraphData) => void;

--- a/packages/cli/lib/mermaid.js
+++ b/packages/cli/lib/mermaid.js
@@ -2,31 +2,88 @@
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.mermaid = void 0;
 const graphai_1 = require("graphai");
-const mapData = (nodeId, inputs) => {
-    (0, graphai_1.inputs2dataSources)(inputs).map((source) => {
+const BASE_INDENT = "  ";
+const sanitizeNodeId = (nodeId) => {
+    return `n_${nodeId.replace(/\./g, "_")}`;
+};
+const getFullNodeId = (nodeId, parentPath) => {
+    return parentPath ? `${parentPath}.${nodeId}` : nodeId;
+};
+const getIndentLevel = (parentPath) => {
+    return parentPath.split(".").filter(Boolean).length;
+};
+const formatLine = (content, depth = 0) => {
+    return BASE_INDENT + BASE_INDENT.repeat(depth) + content;
+};
+const processConnections = (inputs, targetNodeId, parentPath, state) => {
+    const depth = getIndentLevel(parentPath);
+    let sources = (0, graphai_1.inputs2dataSources)(inputs);
+    if (!Array.isArray(sources)) {
+        sources = [sources];
+    }
+    sources.forEach((source) => {
         if (source.nodeId) {
-            if (source.propIds) {
-                console.log(` ${source.nodeId}(${source.nodeId}) -- ${source.propIds.join(".")} --> ${nodeId}`);
-            }
-            else {
-                console.log(` ${source.nodeId}(${source.nodeId}) --> ${nodeId}`);
-            }
+            const sourceFullId = getFullNodeId(source.nodeId, parentPath);
+            const sourceMermaidId = sanitizeNodeId(sourceFullId);
+            const targetMermaidId = sanitizeNodeId(targetNodeId);
+            const connection = source.propIds
+                ? `${sourceMermaidId} -- ${source.propIds.join(".")} --> ${targetMermaidId}`
+                : `${sourceMermaidId} --> ${targetMermaidId}`;
+            state.lines.push(formatLine(connection, depth));
         }
     });
 };
+const processNode = (nodeId, node, parentPath, state) => {
+    const fullNodeId = getFullNodeId(nodeId, parentPath);
+    const mermaidNodeId = sanitizeNodeId(fullNodeId);
+    const depth = getIndentLevel(parentPath);
+    if ("graph" in node) {
+        state.lines.push(formatLine(`subgraph ${mermaidNodeId}[${nodeId}: ${node.agent || ""}]`, depth));
+        if (node.graph && typeof node.graph === "object" && node.graph.nodes) {
+            Object.entries(node.graph.nodes).forEach(([subNodeId, subNode]) => {
+                processNode(subNodeId, subNode, fullNodeId, state);
+            });
+        }
+        state.lines.push(formatLine("end", depth));
+        state.nestedGraphNodes.push(mermaidNodeId);
+    }
+    else if ("agent" in node) {
+        state.lines.push(formatLine(`${mermaidNodeId}(${nodeId}<br/>${node.agent})`, depth));
+        state.computedNodes.push(mermaidNodeId);
+    }
+    else {
+        state.lines.push(formatLine(`${mermaidNodeId}(${nodeId})`, depth));
+        state.staticNodes.push(mermaidNodeId);
+    }
+    if (node.inputs) {
+        processConnections(node.inputs, fullNodeId, parentPath, state);
+    }
+    if ("update" in node) {
+        processConnections({ update: node.update }, fullNodeId, parentPath, state);
+    }
+};
+const addNodeClasses = (state) => {
+    if (state.staticNodes.length > 0) {
+        state.lines.push(formatLine(`class ${state.staticNodes.join(",")} staticNode`));
+    }
+    if (state.computedNodes.length > 0) {
+        state.lines.push(formatLine(`class ${state.computedNodes.join(",")} computedNode`));
+    }
+    if (state.nestedGraphNodes.length > 0) {
+        state.lines.push(formatLine(`class ${state.nestedGraphNodes.join(",")} nestedGraph`));
+    }
+};
 const mermaid = (graphData) => {
-    console.log("flowchart TD");
-    Object.keys(graphData.nodes).forEach((nodeId) => {
-        const node = graphData.nodes[nodeId];
-        // label / name
-        if ("agent" in node) {
-            if (node.inputs) {
-                mapData(nodeId, node.inputs);
-            }
-        }
-        if ("update" in node) {
-            mapData(nodeId, { update: node.update });
-        }
+    const state = {
+        lines: ["flowchart TD"],
+        staticNodes: [],
+        computedNodes: [],
+        nestedGraphNodes: [],
+    };
+    Object.entries(graphData.nodes).forEach(([nodeId, node]) => {
+        processNode(nodeId, node, "", state);
     });
+    addNodeClasses(state);
+    console.log(state.lines.join("\n"));
 };
 exports.mermaid = mermaid;

--- a/packages/cli/scripts/test.sh
+++ b/packages/cli/scripts/test.sh
@@ -5,6 +5,7 @@ node lib/graphai_cli.js test_yaml/bypass2.json
 node lib/graphai_cli.js test_yaml/map1.yaml
 node lib/graphai_cli.js test_yaml/test_base.yml
 node lib/graphai_cli.js test_yaml/test_base.yml -v
+node lib/graphai_cli.js test_yaml/map1.yml -m
 yarn run cli -l
 yarn run cli -d slashGPTAgent
 yarn run cli -s stringEmbeddingsAgent

--- a/packages/cli/src/mermaid.ts
+++ b/packages/cli/src/mermaid.ts
@@ -1,29 +1,110 @@
-import { GraphData, inputs2dataSources } from "graphai";
+import { type GraphData, inputs2dataSources } from "graphai";
 
-const mapData = (nodeId: string, inputs: any) => {
-  inputs2dataSources(inputs).map((source) => {
+type MermaidState = {
+  lines: string[];
+  staticNodes: string[];
+  computedNodes: string[];
+  nestedGraphNodes: string[];
+};
+
+const BASE_INDENT = "  ";
+
+const sanitizeNodeId = (nodeId: string): string => {
+  return `n_${nodeId.replace(/\./g, "_")}`;
+};
+
+const getFullNodeId = (nodeId: string, parentPath: string): string => {
+  return parentPath ? `${parentPath}.${nodeId}` : nodeId;
+};
+
+const getIndentLevel = (parentPath: string): number => {
+  return parentPath.split(".").filter(Boolean).length;
+};
+
+const formatLine = (content: string, depth: number = 0): string => {
+  return BASE_INDENT + BASE_INDENT.repeat(depth) + content;
+};
+
+const processConnections = (inputs: any, targetNodeId: string, parentPath: string, state: MermaidState): void => {
+  const depth = getIndentLevel(parentPath);
+  let sources = inputs2dataSources(inputs);
+  if (!Array.isArray(sources)) {
+    sources = [sources];
+  }
+
+  sources.forEach((source) => {
     if (source.nodeId) {
-      if (source.propIds) {
-        console.log(` ${source.nodeId}(${source.nodeId}) -- ${source.propIds.join(".")} --> ${nodeId}`);
-      } else {
-        console.log(` ${source.nodeId}(${source.nodeId}) --> ${nodeId}`);
-      }
+      const sourceFullId = getFullNodeId(source.nodeId, parentPath);
+      const sourceMermaidId = sanitizeNodeId(sourceFullId);
+      const targetMermaidId = sanitizeNodeId(targetNodeId);
+
+      const connection = source.propIds
+        ? `${sourceMermaidId} -- ${source.propIds.join(".")} --> ${targetMermaidId}`
+        : `${sourceMermaidId} --> ${targetMermaidId}`;
+
+      state.lines.push(formatLine(connection, depth));
     }
   });
 };
 
-export const mermaid = (graphData: GraphData) => {
-  console.log("flowchart TD");
-  Object.keys(graphData.nodes).forEach((nodeId) => {
-    const node = graphData.nodes[nodeId];
-    // label / name
-    if ("agent" in node) {
-      if (node.inputs) {
-        mapData(nodeId, node.inputs);
-      }
+const processNode = (nodeId: string, node: any, parentPath: string, state: MermaidState): void => {
+  const fullNodeId = getFullNodeId(nodeId, parentPath);
+  const mermaidNodeId = sanitizeNodeId(fullNodeId);
+  const depth = getIndentLevel(parentPath);
+
+  if ("graph" in node) {
+    state.lines.push(formatLine(`subgraph ${mermaidNodeId}[${nodeId}: ${node.agent || ""}]`, depth));
+
+    if (node.graph && typeof node.graph === "object" && node.graph.nodes) {
+      Object.entries(node.graph.nodes).forEach(([subNodeId, subNode]) => {
+        processNode(subNodeId, subNode, fullNodeId, state);
+      });
     }
-    if ("update" in node) {
-      mapData(nodeId, { update: node.update });
-    }
+
+    state.lines.push(formatLine("end", depth));
+    state.nestedGraphNodes.push(mermaidNodeId);
+  } else if ("agent" in node) {
+    state.lines.push(formatLine(`${mermaidNodeId}(${nodeId}<br/>${node.agent})`, depth));
+    state.computedNodes.push(mermaidNodeId);
+  } else {
+    state.lines.push(formatLine(`${mermaidNodeId}(${nodeId})`, depth));
+    state.staticNodes.push(mermaidNodeId);
+  }
+
+  if (node.inputs) {
+    processConnections(node.inputs, fullNodeId, parentPath, state);
+  }
+
+  if ("update" in node) {
+    processConnections({ update: node.update }, fullNodeId, parentPath, state);
+  }
+};
+
+const addNodeClasses = (state: MermaidState): void => {
+  if (state.staticNodes.length > 0) {
+    state.lines.push(formatLine(`class ${state.staticNodes.join(",")} staticNode`));
+  }
+  if (state.computedNodes.length > 0) {
+    state.lines.push(formatLine(`class ${state.computedNodes.join(",")} computedNode`));
+  }
+  if (state.nestedGraphNodes.length > 0) {
+    state.lines.push(formatLine(`class ${state.nestedGraphNodes.join(",")} nestedGraph`));
+  }
+};
+
+export const mermaid = (graphData: GraphData): void => {
+  const state: MermaidState = {
+    lines: ["flowchart TD"],
+    staticNodes: [],
+    computedNodes: [],
+    nestedGraphNodes: [],
+  };
+
+  Object.entries(graphData.nodes).forEach(([nodeId, node]) => {
+    processNode(nodeId, node, "", state);
   });
+
+  addNodeClasses(state);
+
+  console.log(state.lines.join("\n"));
 };

--- a/packages/cli/tests/test_mermaid.ts
+++ b/packages/cli/tests/test_mermaid.ts
@@ -1,0 +1,201 @@
+import { mermaid } from "../src/mermaid";
+import { type GraphData } from "graphai";
+import test from "node:test";
+import assert from "node:assert";
+
+const captureConsoleOutput = (fn: () => void): string => {
+  const originalLog = console.log;
+  const output: string[] = [];
+  console.log = (message: string) => output.push(message);
+  
+  try {
+    fn();
+    return output.join("\n");
+  } finally {
+    console.log = originalLog;
+  }
+};
+
+const assertOutputContains = (output: string, expectedStrings: string[]): void => {
+  expectedStrings.forEach(expected => {
+    assert(output.includes(expected), `Expected output to contain: "${expected}"`);
+  });
+};
+
+test("test mermaid with simple graph", async () => {
+  const graphData: GraphData = {
+    version: 0.5,
+    nodes: {
+      message: {
+        value: "Hello World",
+      },
+      echo: {
+        agent: "echoAgent",
+        inputs: { text: ":message" },
+      },
+    },
+  };
+
+  const output = captureConsoleOutput(() => mermaid(graphData));
+
+  assertOutputContains(output, [
+    "flowchart TD",
+    "  n_message(message)",
+    "  n_echo(echo<br/>echoAgent)",
+    "  n_message --> n_echo",
+    "  class n_message staticNode",
+    "  class n_echo computedNode"
+  ]);
+});
+
+test("test mermaid with nested graph", async () => {
+  const graphData: GraphData = {
+    version: 0.5,
+    nodes: {
+      outer: {
+        agent: "nestedAgent",
+        graph: {
+          nodes: {
+            inner1: {
+              value: "Inner Value 1",
+            },
+            inner2: {
+              agent: "copyAgent",
+              inputs: { text: ":inner1" },
+            },
+          },
+        },
+      },
+    },
+  };
+
+  const output = captureConsoleOutput(() => mermaid(graphData));
+
+  assertOutputContains(output, [
+    "flowchart TD",
+    "  subgraph n_outer[outer: nestedAgent]",
+    "    n_outer_inner1(inner1)",
+    "    n_outer_inner2(inner2<br/>copyAgent)",
+    "    n_outer_inner1 --> n_outer_inner2",
+    "  end",
+    "  class n_outer nestedGraph",
+    "  class n_outer_inner1 staticNode",
+    "  class n_outer_inner2 computedNode"
+  ]);
+});
+
+test("test mermaid with connections and properties", async () => {
+  const graphData: GraphData = {
+    version: 0.5,
+    nodes: {
+      data: {
+        value: {
+          name: "John",
+          age: 30,
+        },
+      },
+      getName: {
+        agent: "copyAgent",
+        inputs: { text: ":data.name" },
+      },
+      getAge: {
+        agent: "copyAgent",
+        inputs: { text: ":data.age" },
+      },
+    },
+  };
+
+  const output = captureConsoleOutput(() => mermaid(graphData));
+
+  assertOutputContains(output, [
+    "flowchart TD",
+    "  n_data(data)",
+    "  n_getName(getName<br/>copyAgent)",
+    "  n_getAge(getAge<br/>copyAgent)",
+    "  n_data -- name --> n_getName",
+    "  n_data -- age --> n_getAge",
+    "  class n_data staticNode",
+    "  class n_getName,n_getAge computedNode"
+  ]);
+});
+
+test("test mermaid with update connections", async () => {
+  const graphData: GraphData = {
+    version: 0.5,
+    nodes: {
+      counter: {
+        value: 0,
+        update: ":increment",
+      },
+      increment: {
+        agent: "incrementAgent",
+        inputs: { value: ":counter" },
+      },
+    },
+  };
+
+  const output = captureConsoleOutput(() => mermaid(graphData));
+
+  assertOutputContains(output, [
+    "flowchart TD",
+    "  n_counter(counter)",
+    "  n_increment(increment<br/>incrementAgent)",
+    "  n_counter --> n_increment",
+    "  n_increment --> n_counter",
+    "  class n_counter staticNode",
+    "  class n_increment computedNode"
+  ]);
+});
+
+test("test mermaid with deeply nested graph", async () => {
+  const graphData: GraphData = {
+    version: 0.5,
+    nodes: {
+      level1: {
+        agent: "nestedAgent",
+        graph: {
+          nodes: {
+            level2: {
+              agent: "nestedAgent",
+              graph: {
+                nodes: {
+                  level3: {
+                    value: "Deep value",
+                  },
+                  processor: {
+                    agent: "processAgent",
+                    inputs: { data: ":level3" },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  };
+
+  const output = captureConsoleOutput(() => mermaid(graphData));
+
+  assertOutputContains(output, [
+    "flowchart TD",
+    "  subgraph n_level1[level1: nestedAgent]",
+    "    subgraph n_level1_level2[level2: nestedAgent]",
+    "      n_level1_level2_level3(level3)",
+    "      n_level1_level2_processor(processor<br/>processAgent)",
+    "      n_level1_level2_level3 --> n_level1_level2_processor",
+    "    end",
+    "  end"
+  ]);
+});
+
+test("test mermaid with empty graph", async () => {
+  const graphData: GraphData = {
+    version: 0.5,
+    nodes: {},
+  };
+
+  const output = captureConsoleOutput(() => mermaid(graphData));
+
+  assert.strictEqual(output, "flowchart TD");
+});

--- a/packages/cli/tests/test_mermaid.ts
+++ b/packages/cli/tests/test_mermaid.ts
@@ -7,7 +7,7 @@ const captureConsoleOutput = (fn: () => void): string => {
   const originalLog = console.log;
   const output: string[] = [];
   console.log = (message: string) => output.push(message);
-  
+
   try {
     fn();
     return output.join("\n");


### PR DESCRIPTION
I have improved the Mermaid output in the CLI, updating it to display agent names and support nested graphs.

```bash
$ node lib/graphai_cli.js test_yaml/map1.yaml -m
flowchart TD
  n_source1(source1)
  n_source2(source2)
  n_source3(source3)
  n_source4(source4)
  subgraph n_nestedNode[nestedNode: mapAgent]
    n_nestedNode_node2(node2<br/>stringTemplateAgent)
  end
  n_source1 -- fruit --> n_nestedNode
  n_source2 -- fruit --> n_nestedNode
  n_source3 -- fruit --> n_nestedNode
  n_source4 -- fruit --> n_nestedNode
  n_result(result<br/>sleeperAgent)
  n_nestedNode --> n_result
  class n_source1,n_source2,n_source3,n_source4 staticNode
  class n_nestedNode_node2,n_result computedNode
  class n_nestedNode nestedGraph
```

<img width="800" height="1072" alt="CleanShot 2025-07-24 at 21 13 33@2x" src="https://github.com/user-attachments/assets/2ba4a475-048c-4e46-904c-889164592185" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced Mermaid diagram generation with improved hierarchical support, allowing for nested subgraphs and clearer node classification.
* **Refactor**
  * Reworked the internal logic for Mermaid diagram creation to provide more organized and readable output.
* **Tests**
  * Added comprehensive tests to ensure accurate Mermaid diagram generation for various graph structures.
* **Chores**
  * Updated CLI test script to include a new sample for Mermaid diagram generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->