### PR TITLE
chore: fix typo in eslint.config.mjs

### DIFF
--- a/agent_filters/cache_agent_filter/eslint.config.mjs
+++ b/agent_filters/cache_agent_filter/eslint.config.mjs
@@ -2,10 +2,10 @@ import eslintBase from "../../config/eslint.config.base.mjs";
 
 export default [
   {
-    files: ["{src,test,samles}/**/*.{js,ts,yaml,yml,json}"],
+    files: ["{src,test,samples}/**/*.{js,ts,yaml,yml,json}"],
   },
   {
-    ignores: ["lib/**/*", "*.ts", "apiDoc/**/*", "apiDoc/*"],
+    ignores: ["lib/**/*", "*.ts", "apiDoc/**/*"],
   },
   ...eslintBase,
 ];

--- a/agent_filters/http_client_agent_filter/eslint.config.mjs
+++ b/agent_filters/http_client_agent_filter/eslint.config.mjs
@@ -2,10 +2,10 @@ import eslintBase from "../../config/eslint.config.base.mjs";
 
 export default [
   {
-    files: ["{src,test,samles}/**/*.{js,ts,yaml,yml,json}"],
+    files: ["{src,test,samples}/**/*.{js,ts,yaml,yml,json}"],
   },
   {
-    ignores: ["lib/**/*", "*.ts", "apiDoc/**/*", "apiDoc/*"],
+    ignores: ["lib/**/*", "*.ts", "apiDoc/**/*"],
   },
   ...eslintBase,
 ];

--- a/agent_filters/namedinput_validator_agent_filter/eslint.config.mjs
+++ b/agent_filters/namedinput_validator_agent_filter/eslint.config.mjs
@@ -2,10 +2,10 @@ import eslintBase from "../../config/eslint.config.base.mjs";
 
 export default [
   {
-    files: ["{src,test,samles}/**/*.{js,ts,yaml,yml,json}"],
+    files: ["{src,test,samples}/**/*.{js,ts,yaml,yml,json}"],
   },
   {
-    ignores: ["lib/**/*", "*.ts", "apiDoc/**/*", "apiDoc/*"],
+    ignores: ["lib/**/*", "*.ts", "apiDoc/**/*"],
   },
   ...eslintBase,
 ];

--- a/agent_filters/step_runner_agent_filter/eslint.config.mjs
+++ b/agent_filters/step_runner_agent_filter/eslint.config.mjs
@@ -2,10 +2,10 @@ import eslintBase from "../../config/eslint.config.base.mjs";
 
 export default [
   {
-    files: ["{src,test,samles}/**/*.{js,ts,yaml,yml,json}"],
+    files: ["{src,test,samples}/**/*.{js,ts,yaml,yml,json}"],
   },
   {
-    ignores: ["lib/**/*", "*.ts", "apiDoc/**/*", "apiDoc/*"],
+    ignores: ["lib/**/*", "*.ts", "apiDoc/**/*"],
   },
   ...eslintBase,
 ];

--- a/agent_filters/stream_agent_filter/eslint.config.mjs
+++ b/agent_filters/stream_agent_filter/eslint.config.mjs
@@ -2,10 +2,10 @@ import eslintBase from "../../config/eslint.config.base.mjs";
 
 export default [
   {
-    files: ["{src,test,samles}/**/*.{js,ts,yaml,yml,json}"],
+    files: ["{src,test,samples}/**/*.{js,ts,yaml,yml,json}"],
   },
   {
-    ignores: ["lib/**/*", "*.ts", "apiDoc/**/*", "apiDoc/*"],
+    ignores: ["lib/**/*", "*.ts", "apiDoc/**/*"],
   },
   ...eslintBase,
 ];

--- a/agent_filters/utils/eslint.config.mjs
+++ b/agent_filters/utils/eslint.config.mjs
@@ -2,10 +2,10 @@ import eslintBase from "../../config/eslint.config.base.mjs";
 
 export default [
   {
-    files: ["{src,test,samles}/**/*.{js,ts,yaml,yml,json}"],
+    files: ["{src,test,samples}/**/*.{js,ts,yaml,yml,json}"],
   },
   {
-    ignores: ["lib/**/*", "*.ts", "apiDoc/**/*", "apiDoc/*"],
+    ignores: ["lib/**/*", "*.ts", "apiDoc/**/*"],
   },
   ...eslintBase,
 ];

--- a/agents/agent_utils/eslint.config.mjs
+++ b/agents/agent_utils/eslint.config.mjs
@@ -2,10 +2,10 @@ import eslintBase from "../../config/eslint.config.base.mjs";
 
 export default [
   {
-    files: ["{src,test,samles}/**/*.{js,ts,yaml,yml,json}"],
+    files: ["{src,test,samples}/**/*.{js,ts,yaml,yml,json}"],
   },
   {
-    ignores: ["lib/**/*", "*.ts", "apiDoc/**/*", "apiDoc/*"],
+    ignores: ["lib/**/*", "*.ts", "apiDoc/**/*"],
   },
   ...eslintBase,
 ];

--- a/agents/data_agents/eslint.config.mjs
+++ b/agents/data_agents/eslint.config.mjs
@@ -2,10 +2,10 @@ import eslintBase from "../../config/eslint.config.base.mjs";
 
 export default [
   {
-    files: ["{src,test,samles}/**/*.{js,ts,yaml,yml,json}"],
+    files: ["{src,test,samples}/**/*.{js,ts,yaml,yml,json}"],
   },
   {
-    ignores: ["lib/**/*", "*.ts", "apiDoc/**/*", "apiDoc/*"],
+    ignores: ["lib/**/*", "*.ts", "apiDoc/**/*"],
   },
   ...eslintBase,
 ];

--- a/agents/input_agents/eslint.config.mjs
+++ b/agents/input_agents/eslint.config.mjs
@@ -2,10 +2,10 @@ import eslintBase from "../../config/eslint.config.base.mjs";
 
 export default [
   {
-    files: ["{src,test,samles}/**/*.{js,ts,yaml,yml,json}"],
+    files: ["{src,test,samples}/**/*.{js,ts,yaml,yml,json}"],
   },
   {
-    ignores: ["lib/**/*", "*.ts", "apiDoc/**/*", "apiDoc/*"],
+    ignores: ["lib/**/*", "*.ts", "apiDoc/**/*"],
   },
   ...eslintBase,
 ];

--- a/agents/llm_agents/eslint.config.mjs
+++ b/agents/llm_agents/eslint.config.mjs
@@ -2,10 +2,10 @@ import eslintBase from "../../config/eslint.config.base.mjs";
 
 export default [
   {
-    files: ["{src,test,samles}/**/*.{js,ts,yaml,yml,json}"],
+    files: ["{src,test,samples}/**/*.{js,ts,yaml,yml,json}"],
   },
   {
-    ignores: ["lib/**/*", "*.ts", "apiDoc/**/*", "apiDoc/*"],
+    ignores: ["lib/**/*", "*.ts", "apiDoc/**/*"],
   },
   ...eslintBase,
 ];

--- a/agents/service_agents/eslint.config.mjs
+++ b/agents/service_agents/eslint.config.mjs
@@ -2,10 +2,10 @@ import eslintBase from "../../config/eslint.config.base.mjs";
 
 export default [
   {
-    files: ["{src,test,samles}/**/*.{js,ts,yaml,yml,json}"],
+    files: ["{src,test,samples}/**/*.{js,ts,yaml,yml,json}"],
   },
   {
-    ignores: ["lib/**/*", "*.ts", "apiDoc/**/*", "apiDoc/*"],
+    ignores: ["lib/**/*", "*.ts", "apiDoc/**/*"],
   },
   ...eslintBase,
 ];

--- a/agents/sleeper_agents/eslint.config.mjs
+++ b/agents/sleeper_agents/eslint.config.mjs
@@ -2,10 +2,10 @@ import eslintBase from "../../config/eslint.config.base.mjs";
 
 export default [
   {
-    files: ["{src,test,samles}/**/*.{js,ts,yaml,yml,json}"],
+    files: ["{src,test,samples}/**/*.{js,ts,yaml,yml,json}"],
   },
   {
-    ignores: ["lib/**/*", "*.ts", "apiDoc/**/*", "apiDoc/*"],
+    ignores: ["lib/**/*", "*.ts", "apiDoc/**/*"],
   },
   ...eslintBase,
 ];

--- a/agents/vanilla_agents/eslint.config.mjs
+++ b/agents/vanilla_agents/eslint.config.mjs
@@ -2,10 +2,10 @@ import eslintBase from "../../config/eslint.config.base.mjs";
 
 export default [
   {
-    files: ["{src,test,samles}/**/*.{js,ts,yaml,yml,json}"],
+    files: ["{src,test,samples}/**/*.{js,ts,yaml,yml,json}"],
   },
   {
-    ignores: ["lib/**/*", "*.ts", "apiDoc/**/*", "apiDoc/*", "dist/*"],
+    ignores: ["lib/**/*", "*.ts", "apiDoc/**/*", "dist/*"],
   },
   ...eslintBase,
 ];

--- a/agents/vanilla_node_agents/eslint.config.mjs
+++ b/agents/vanilla_node_agents/eslint.config.mjs
@@ -2,10 +2,10 @@ import eslintBase from "../../config/eslint.config.base.mjs";
 
 export default [
   {
-    files: ["{src,test,samles}/**/*.{js,ts,yaml,yml,json}"],
+    files: ["{src,test,samples}/**/*.{js,ts,yaml,yml,json}"],
   },
   {
-    ignores: ["lib/**/*", "*.ts", "apiDoc/**/*", "apiDoc/*", "dist/*"],
+    ignores: ["lib/**/*", "*.ts", "apiDoc/**/*", "dist/*"],
   },
   ...eslintBase,
 ];

--- a/llm_agents/anthropic_agent/eslint.config.mjs
+++ b/llm_agents/anthropic_agent/eslint.config.mjs
@@ -2,10 +2,10 @@ import eslintBase from "../../config/eslint.config.base.mjs";
 
 export default [
   {
-    files: ["{src,test,samles}/**/*.{js,ts,yaml,yml,json}"],
+    files: ["{src,test,samples}/**/*.{js,ts,yaml,yml,json}"],
   },
   {
-    ignores: ["lib/**/*", "*.ts", "apiDoc/**/*", "apiDoc/*"],
+    ignores: ["lib/**/*", "*.ts", "apiDoc/**/*"],
   },
   ...eslintBase,
 ];

--- a/llm_agents/gemini_agent/eslint.config.mjs
+++ b/llm_agents/gemini_agent/eslint.config.mjs
@@ -2,10 +2,10 @@ import eslintBase from "../../config/eslint.config.base.mjs";
 
 export default [
   {
-    files: ["{src,test,samles}/**/*.{js,ts,yaml,yml,json}"],
+    files: ["{src,test,samples}/**/*.{js,ts,yaml,yml,json}"],
   },
   {
-    ignores: ["lib/**/*", "*.ts", "apiDoc/**/*", "apiDoc/*"],
+    ignores: ["lib/**/*", "*.ts", "apiDoc/**/*"],
   },
   ...eslintBase,
 ];

--- a/llm_agents/groq_agent/eslint.config.mjs
+++ b/llm_agents/groq_agent/eslint.config.mjs
@@ -2,10 +2,10 @@ import eslintBase from "../../config/eslint.config.base.mjs";
 
 export default [
   {
-    files: ["{src,test,samles}/**/*.{js,ts,yaml,yml,json}"],
+    files: ["{src,test,samples}/**/*.{js,ts,yaml,yml,json}"],
   },
   {
-    ignores: ["lib/**/*", "*.ts", "apiDoc/**/*", "apiDoc/*"],
+    ignores: ["lib/**/*", "*.ts", "apiDoc/**/*"],
   },
   ...eslintBase,
 ];

--- a/llm_agents/llm_utils/eslint.config.mjs
+++ b/llm_agents/llm_utils/eslint.config.mjs
@@ -2,10 +2,10 @@ import eslintBase from "../../config/eslint.config.base.mjs";
 
 export default [
   {
-    files: ["{src,test,samles}/**/*.{js,ts,yaml,yml,json}"],
+    files: ["{src,test,samples}/**/*.{js,ts,yaml,yml,json}"],
   },
   {
-    ignores: ["lib/**/*", "*.ts", "apiDoc/**/*", "apiDoc/*"],
+    ignores: ["lib/**/*", "*.ts", "apiDoc/**/*"],
   },
   ...eslintBase,
 ];

--- a/llm_agents/openai_agent/eslint.config.mjs
+++ b/llm_agents/openai_agent/eslint.config.mjs
@@ -2,10 +2,10 @@ import eslintBase from "../../config/eslint.config.base.mjs";
 
 export default [
   {
-    files: ["{src,test,samles}/**/*.{js,ts,yaml,yml,json}"],
+    files: ["{src,test,samples}/**/*.{js,ts,yaml,yml,json}"],
   },
   {
-    ignores: ["lib/**/*", "*.ts", "apiDoc/**/*", "apiDoc/*"],
+    ignores: ["lib/**/*", "*.ts", "apiDoc/**/*"],
   },
   ...eslintBase,
 ];

--- a/llm_agents/openai_fetch_agent/eslint.config.mjs
+++ b/llm_agents/openai_fetch_agent/eslint.config.mjs
@@ -2,10 +2,10 @@ import eslintBase from "../../config/eslint.config.base.mjs";
 
 export default [
   {
-    files: ["{src,test,samles}/**/*.{js,ts,yaml,yml,json}"],
+    files: ["{src,test,samples}/**/*.{js,ts,yaml,yml,json}"],
   },
   {
-    ignores: ["lib/**/*", "*.ts", "apiDoc/**/*", "apiDoc/*"],
+    ignores: ["lib/**/*", "*.ts", "apiDoc/**/*"],
   },
   ...eslintBase,
 ];

--- a/llm_agents/replicate_agent/eslint.config.mjs
+++ b/llm_agents/replicate_agent/eslint.config.mjs
@@ -2,10 +2,10 @@ import eslintBase from "../../config/eslint.config.base.mjs";
 
 export default [
   {
-    files: ["{src,test,samles}/**/*.{js,ts,yaml,yml,json}"],
+    files: ["{src,test,samples}/**/*.{js,ts,yaml,yml,json}"],
   },
   {
-    ignores: ["lib/**/*", "*.ts", "apiDoc/**/*", "apiDoc/*"],
+    ignores: ["lib/**/*", "*.ts", "apiDoc/**/*"],
   },
   ...eslintBase,
 ];

--- a/llm_agents/slashgpt_agent/eslint.config.mjs
+++ b/llm_agents/slashgpt_agent/eslint.config.mjs
@@ -2,10 +2,10 @@ import eslintBase from "../../config/eslint.config.base.mjs";
 
 export default [
   {
-    files: ["{src,test,samles}/**/*.{js,ts,yaml,yml,json}"],
+    files: ["{src,test,samples}/**/*.{js,ts,yaml,yml,json}"],
   },
   {
-    ignores: ["lib/**/*", "*.ts", "apiDoc/**/*", "apiDoc/*"],
+    ignores: ["lib/**/*", "*.ts", "apiDoc/**/*"],
   },
   ...eslintBase,
 ];

--- a/llm_agents/token_bound_string_agent/eslint.config.mjs
+++ b/llm_agents/token_bound_string_agent/eslint.config.mjs
@@ -2,10 +2,10 @@ import eslintBase from "../../config/eslint.config.base.mjs";
 
 export default [
   {
-    files: ["{src,test,samles}/**/*.{js,ts,yaml,yml,json}"],
+    files: ["{src,test,samples}/**/*.{js,ts,yaml,yml,json}"],
   },
   {
-    ignores: ["lib/**/*", "*.ts", "apiDoc/**/*", "apiDoc/*"],
+    ignores: ["lib/**/*", "*.ts", "apiDoc/**/*"],
   },
   ...eslintBase,
 ];

--- a/llm_agents/tools_agent/eslint.config.mjs
+++ b/llm_agents/tools_agent/eslint.config.mjs
@@ -2,10 +2,10 @@ import eslintBase from "../../config/eslint.config.base.mjs";
 
 export default [
   {
-    files: ["{src,test,samles}/**/*.{js,ts,yaml,yml,json}"],
+    files: ["{src,test,samples}/**/*.{js,ts,yaml,yml,json}"],
   },
   {
-    ignores: ["lib/**/*", "*.ts", "apiDoc/**/*", "apiDoc/*"],
+    ignores: ["lib/**/*", "*.ts", "apiDoc/**/*"],
   },
   ...eslintBase,
 ];

--- a/packages/agent_filters/eslint.config.mjs
+++ b/packages/agent_filters/eslint.config.mjs
@@ -2,10 +2,10 @@ import eslintBase from "../../config/eslint.config.base.mjs";
 
 export default [
   {
-    files: ["{src,test,samles}/**/*.{js,ts,yaml,yml,json}"],
+    files: ["{src,test,samples}/**/*.{js,ts,yaml,yml,json}"],
   },
   {
-    ignores: ["lib/**/*", "*.ts", "apiDoc/**/*", "apiDoc/*"],
+    ignores: ["lib/**/*", "*.ts", "apiDoc/**/*"],
   },
   ...eslintBase,
 ];

--- a/packages/agentdoc/eslint.config.mjs
+++ b/packages/agentdoc/eslint.config.mjs
@@ -2,7 +2,7 @@ import eslintBase from "../../config/eslint.config.base.mjs";
 
 export default [
   {
-    files: ["{src,test,samles}/**/*.{js,ts,yaml,yml,json}"],
+    files: ["{src,test,samples}/**/*.{js,ts,yaml,yml,json}"],
   },
   {
     ignores: ["lib/**/*", "*.ts"],

--- a/packages/agents/eslint.config.mjs
+++ b/packages/agents/eslint.config.mjs
@@ -2,10 +2,10 @@ import eslintBase from "../../config/eslint.config.base.mjs";
 
 export default [
   {
-    files: ["{src,test,samles}/**/*.{js,ts,yaml,yml,json}"],
+    files: ["{src,test,samples}/**/*.{js,ts,yaml,yml,json}"],
   },
   {
-    ignores: ["lib/**/*", "*.ts", "apiDoc/**/*", "apiDoc/*"],
+    ignores: ["lib/**/*", "*.ts", "apiDoc/**/*"],
   },
   ...eslintBase,
 ];

--- a/packages/cli/eslint.config.mjs
+++ b/packages/cli/eslint.config.mjs
@@ -2,7 +2,7 @@ import eslintBase from "../../config/eslint.config.base.mjs";
 
 export default [
   {
-    files: ["{src,test,samles}/**/*.{js,ts,yaml,yml,json}"],
+    files: ["{src,test,samples}/**/*.{js,ts,yaml,yml,json}"],
   },
   {
     ignores: ["lib/**/*", "*.ts"],

--- a/packages/graphai/eslint.config.mjs
+++ b/packages/graphai/eslint.config.mjs
@@ -2,10 +2,10 @@ import eslintBase from "../../config/eslint.config.base.mjs";
 
 export default [
   {
-    files: ["{src,test,samles}/**/*.{js,ts,yaml,yml,json}"],
+    files: ["{src,test,samples}/**/*.{js,ts,yaml,yml,json}"],
   },
   {
-    ignores: ["lib/**/*", "*.ts", "apiDoc/**/*", "apiDoc/*", "dist/*"],
+    ignores: ["lib/**/*", "*.ts", "apiDoc/**/*", "dist/*"],
   },
   ...eslintBase,
 ];

--- a/packages/lite/eslint.config.mjs
+++ b/packages/lite/eslint.config.mjs
@@ -2,10 +2,10 @@ import eslintBase from "../../config/eslint.config.base.mjs";
 
 export default [
   {
-    files: ["{src,test,samles}/**/*.{js,ts,yaml,yml,json}"],
+    files: ["{src,test,samples}/**/*.{js,ts,yaml,yml,json}"],
   },
   {
-    ignores: ["lib/**/*", "*.ts", "apiDoc/**/*", "apiDoc/*"],
+    ignores: ["lib/**/*", "*.ts", "apiDoc/**/*"],
   },
   ...eslintBase,
 ];

--- a/packages/samples/eslint.config.mjs
+++ b/packages/samples/eslint.config.mjs
@@ -2,10 +2,10 @@ import eslintBase from "../../config/eslint.config.base.mjs";
 
 export default [
   {
-    files: ["{src,test,samles}/**/*.{js,ts,json}"],
+    files: ["{src,test,samples}/**/*.{js,ts,json}"],
   },
   {
-    ignores: ["lib/**/*", "*.ts", "apiDoc/**/*", "apiDoc/*"],
+    ignores: ["lib/**/*", "*.ts", "apiDoc/**/*"],
   },
   ...eslintBase,
 ];

--- a/packages/test_utils/eslint.config.mjs
+++ b/packages/test_utils/eslint.config.mjs
@@ -2,10 +2,10 @@ import eslintBase from "../../config/eslint.config.base.mjs";
 
 export default [
   {
-    files: ["{src,test,samles}/**/*.{js,ts,yaml,yml,json}"],
+    files: ["{src,test,samples}/**/*.{js,ts,yaml,yml,json}"],
   },
   {
-    ignores: ["lib/**/*", "*.ts", "apiDoc/**/*", "apiDoc/*"],
+    ignores: ["lib/**/*", "*.ts", "apiDoc/**/*"],
   },
   ...eslintBase,
 ];


### PR DESCRIPTION
esling.config.mjs 内のタイポ修正
- samles → samples

合わせて、 `"apiDoc/*"` は `"apiDoc/**/*"` に包含されており、冗長かと思うので削除

yarn run eslint を実行して差分がないことを確認済み

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Standardized linting setup across the project by correcting directory patterns to include the samples directory and removing redundant ignore rules. This expands lint coverage and improves consistency.
  - Enhances maintainability and code quality for contributors; no changes to runtime behavior, APIs, or UI.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->