### PR TITLE
openai max token change to max_completion_tokens

### DIFF
--- a/llm_agents/openai_agent/src/openai_agent.ts
+++ b/llm_agents/openai_agent/src/openai_agent.ts
@@ -18,6 +18,7 @@ type OpenAIInputs = {
   images?: string[];
   tools?: OpenAI.ChatCompletionTool[];
   tool_choice?: OpenAI.ChatCompletionToolChoiceOption;
+  // Deprecated alias for compatibility with older graphs
   max_tokens?: number;
   max_completion_tokens?: number;
   verbose?: boolean;

--- a/llm_agents/openai_agent/src/openai_agent.ts
+++ b/llm_agents/openai_agent/src/openai_agent.ts
@@ -19,6 +19,7 @@ type OpenAIInputs = {
   tools?: OpenAI.ChatCompletionTool[];
   tool_choice?: OpenAI.ChatCompletionToolChoiceOption;
   max_tokens?: number;
+  max_completion_tokens?: number;
   verbose?: boolean;
   temperature?: number;
   messages?: Array<OpenAI.ChatCompletionMessageParam>;
@@ -124,7 +125,7 @@ const convertOpenAIChatCompletion = (
 };
 
 export const openAIAgent: AgentFunction<OpenAIParams, OpenAIResult, OpenAIInputs, OpenAIConfig> = async ({ filterParams, params, namedInputs, config }) => {
-  const { verbose, system, images, temperature, tools, tool_choice, max_tokens, prompt, messages, message, response_format } = {
+  const { verbose, system, images, temperature, tools, tool_choice, max_tokens, max_completion_tokens, prompt, messages, message, response_format } = {
     ...params,
     ...namedInputs,
   };
@@ -177,7 +178,7 @@ export const openAIAgent: AgentFunction<OpenAIParams, OpenAIResult, OpenAIInputs
     messages: messagesCopy as unknown as OpenAI.ChatCompletionMessageParam[],
     tools,
     tool_choice,
-    max_tokens,
+    max_completion_tokens: max_completion_tokens ?? max_tokens,
     response_format,
   };
 
@@ -296,7 +297,7 @@ const openaiAgentInfo: AgentFunctionInfo = {
       tool_choice: {
         anyOf: [{ type: "array" }, { type: "object" }],
       },
-      max_tokens: { type: "number" },
+      max_completion_tokens: { type: "number" },
       verbose: { type: "boolean" },
       temperature: { type: "number" },
       baseURL: { type: "string" },
@@ -408,7 +409,7 @@ const openaiAgentInfo: AgentFunctionInfo = {
       system: { type: "string" },
       tools: { type: "object" },
       tool_choice: { anyOf: [{ type: "array" }, { type: "object" }] },
-      max_tokens: { type: "number" },
+      max_completion_tokens: { type: "number" },
       verbose: { type: "boolean" },
       temperature: { type: "number" },
       baseURL: { type: "string" },

--- a/llm_agents/openai_agent/tests/graphData.ts
+++ b/llm_agents/openai_agent/tests/graphData.ts
@@ -9,6 +9,9 @@ export const graphDataOpenAIMath = {
       inputs: {
         prompt: ":inputData",
       },
+      params: {
+        max_tokens: 2000,
+      },
     },
   },
 };

--- a/llm_agents/openai_fetch_agent/src/openai_fetch_agent.ts
+++ b/llm_agents/openai_fetch_agent/src/openai_fetch_agent.ts
@@ -7,6 +7,7 @@ type OpenAIInputs = {
   images?: string[];
   tools?: OpenAI.ChatCompletionTool[];
   tool_choice?: OpenAI.ChatCompletionToolChoiceOption;
+  // Deprecated alias for compatibility with older graphs
   max_tokens?: number;
   max_completion_tokens?: number;
   verbose?: boolean;

--- a/llm_agents/openai_fetch_agent/src/openai_fetch_agent.ts
+++ b/llm_agents/openai_fetch_agent/src/openai_fetch_agent.ts
@@ -8,6 +8,7 @@ type OpenAIInputs = {
   tools?: OpenAI.ChatCompletionTool[];
   tool_choice?: OpenAI.ChatCompletionToolChoiceOption;
   max_tokens?: number;
+  max_completion_tokens?: number;
   verbose?: boolean;
   temperature?: number;
   messages?: Array<OpenAI.ChatCompletionMessageParam>;
@@ -61,7 +62,7 @@ export const openAIFetchAgent: AgentFunction<OpenAIParams, Record<string, any> |
   namedInputs,
   config,
 }) => {
-  const { verbose, system, images, temperature, tools, tool_choice, max_tokens, prompt, messages, response_format } = {
+  const { verbose, system, images, temperature, tools, tool_choice, max_tokens, max_completion_tokens, prompt, messages, response_format } = {
     ...params,
     ...namedInputs,
   };
@@ -114,7 +115,7 @@ export const openAIFetchAgent: AgentFunction<OpenAIParams, Record<string, any> |
     messages: messagesCopy as unknown as OpenAI.ChatCompletionMessageParam[],
     tools,
     tool_choice,
-    max_tokens,
+    max_completion_tokens: max_completion_tokens ?? max_tokens,
     temperature: temperature ?? 0.7,
     stream: !!stream,
     response_format,
@@ -249,7 +250,7 @@ const openAIFetchAgentInfo: AgentFunctionInfo = {
       tool_choice: {
         anyOf: [{ type: "array" }, { type: "object" }],
       },
-      max_tokens: { type: "number" },
+      max_completion_tokens: { type: "number" },
       verbose: { type: "boolean" },
       temperature: { type: "number" },
       baseURL: { type: "string" },
@@ -361,7 +362,7 @@ const openAIFetchAgentInfo: AgentFunctionInfo = {
       system: { type: "string" },
       tools: { type: "object" },
       tool_choice: { anyOf: [{ type: "array" }, { type: "object" }] },
-      max_tokens: { type: "number" },
+      max_completion_tokens: { type: "number" },
       verbose: { type: "boolean" },
       temperature: { type: "number" },
       baseURL: { type: "string" },


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added max_completion_tokens to OpenAI and OpenAI Fetch agents for explicit control of completion token limits, with automatic fallback to existing max_tokens.

* **Refactor**
  * Updated public input/parameter schema to use max_completion_tokens instead of max_tokens, aligning interfaces while preserving backward compatibility.

* **Tests**
  * Expanded test graph data to include a max_tokens-based params entry to exercise the new parameter mapping.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->