### PR TITLE
Bump default Gemini model to `gemini-2.5-flash`

### DIFF
--- a/llm_agents/gemini_agent/lib/gemini_agent.js
+++ b/llm_agents/gemini_agent/lib/gemini_agent.js
@@ -75,7 +75,7 @@ const geminiAgent = async ({ params, namedInputs, config, filterParams }) => {
         },
     ];
     const modelParams = {
-        model: model || "gemini-1.5-flash",
+        model: model || "gemini-2.5-flash",
         safetySettings,
     };
     /*

--- a/llm_agents/gemini_agent/src/gemini_agent.ts
+++ b/llm_agents/gemini_agent/src/gemini_agent.ts
@@ -118,7 +118,7 @@ export const geminiAgent: AgentFunction<GeminiParams, GeminiResult, GeminiInputs
   ];
 
   const modelParams: ModelParams = {
-    model: model || "gemini-1.5-flash",
+    model: model || "gemini-2.5-flash",
     safetySettings,
   };
   /*


### PR DESCRIPTION
Resolves #1248.

Because `gemini-1.5-flash` already retired.
https://docs.cloud.google.com/vertex-ai/generative-ai/docs/learn/model-versions#retired-models

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the default model used by the Gemini integration to the latest version.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->