### PR TITLE
feat: add Azure OpenAI support to openAIAgent

### DIFF
--- a/llm_agents/openai_agent/tests/run_azure.ts
+++ b/llm_agents/openai_agent/tests/run_azure.ts
@@ -1,0 +1,58 @@
+import "dotenv/config";
+import { defaultTestContext } from "graphai";
+import { openAIAgent } from "../src/openai_agent";
+
+import test from "node:test";
+import assert from "node:assert";
+
+const baseURL = process.env.AZURE_OPENAI_ENDPOINT;
+const apiKey = process.env.AZURE_OPENAI_API_KEY;
+const apiVersion = process.env.AZURE_OPENAI_API_VERSION;
+
+if (!baseURL || !apiKey) {
+  console.error("AZURE_OPENAI_ENDPOINT and AZURE_OPENAI_API_KEY are required");
+  process.exit(1);
+}
+
+test("test azure openai", async () => {
+  const namedInputs = { prompt: ["hello, let me know the answer 1 + 1"] };
+  const config = { baseURL, apiKey, apiVersion };
+  const res = (await openAIAgent({ ...defaultTestContext, namedInputs, config })) as any;
+
+  if (res) {
+    console.log(res.choices[0].message["content"]);
+  }
+  assert.deepStrictEqual(true, true);
+});
+
+test("test azure openai with model", async () => {
+  const namedInputs = { prompt: ["hello, what is the capital of Japan?"] };
+  const config = { baseURL, apiKey, apiVersion, model: "gpt-4o" };
+  const res = (await openAIAgent({ ...defaultTestContext, namedInputs, config })) as any;
+
+  if (res) {
+    console.log(res.choices[0].message["content"]);
+  }
+  assert.deepStrictEqual(true, true);
+});
+
+test("test azure openai stream", async () => {
+  const namedInputs = { prompt: ["hello, let me know the answer 1 + 1"] };
+  const config = { baseURL, apiKey, apiVersion, stream: true };
+  const res = (await openAIAgent({
+    ...defaultTestContext,
+    namedInputs,
+    config,
+    filterParams: {
+      streamTokenCallback: (token: string) => {
+        process.stdout.write(token);
+      },
+    },
+  })) as any;
+
+  console.log("\n--- Final result ---");
+  if (res) {
+    console.log(res.choices[0].message["content"]);
+  }
+  assert.deepStrictEqual(true, true);
+});


### PR DESCRIPTION
## Summary

- Add Azure OpenAI support to `openAIAgent` by auto-detecting Azure endpoints
- When `baseURL` contains `.openai.azure.com`, automatically use `AzureOpenAI` client
- Add `apiVersion` config option for Azure API version (defaults to `2025-04-01-preview`)

## Changes

- Import `AzureOpenAI` class from openai package
- Add `apiVersion` to `OpenAIConfig` type
- Auto-detect Azure endpoints by checking if hostname ends with `.openai.azure.com`
- Add `apiVersion` to inputs and params schema
- Add `run_azure.ts` test for Azure OpenAI

## Usage

```typescript
const config = {
  baseURL: "https://your-resource.openai.azure.com/",
  apiKey: process.env.AZURE_OPENAI_API_KEY,
  apiVersion: "2025-04-01-preview", // optional
  model: "gpt-4o", // deployment name
};
```

## Test plan

- [x] Test with Azure OpenAI endpoint (Sweden Central)
- [x] Test streaming mode
- [x] Verify standard OpenAI still works (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Azure OpenAI support: The agent now automatically detects and initializes Azure OpenAI deployments when a baseURL pointing to Azure is configured.
  * API version parameter: Added optional apiVersion configuration for Azure-specific deployment requirements, with a sensible default provided.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->