### PR TITLE
chore: add prepack and publishConfig to all workspace packages

### DIFF
--- a/agent_filters/cache_agent_filter/package.json
+++ b/agent_filters/cache_agent_filter/package.json
@@ -12,7 +12,8 @@
     "format": "prettier --write '{src,tests}/**/*.ts'",
     "test": "node --test --require ts-node/register ./tests/test_*.ts",
     "doc": "echo nothing",
-    "b": "yarn run format && yarn run eslint && yarn run build"
+    "b": "yarn run format && yarn run eslint && yarn run build",
+    "prepack": "yarn build"
   },
   "repository": {
     "type": "git",
@@ -31,5 +32,8 @@
   "types": "./lib/index.d.ts",
   "directories": {
     "lib": "lib"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/agent_filters/http_client_agent_filter/package.json
+++ b/agent_filters/http_client_agent_filter/package.json
@@ -12,7 +12,8 @@
     "format": "prettier --write '{src,tests}/**/*.ts'",
     "test": "echo nothing",
     "doc": "echo nothing",
-    "b": "yarn run format && yarn run eslint && yarn run build"
+    "b": "yarn run format && yarn run eslint && yarn run build",
+    "prepack": "yarn build"
   },
   "repository": {
     "type": "git",
@@ -24,10 +25,13 @@
     "url": "https://github.com/receptron/graphai/issues"
   },
   "homepage": "https://github.com/receptron/graphai#readme",
-  "dependencies": { },
+  "dependencies": {},
   "devDependencies": {},
   "types": "./lib/index.d.ts",
   "directories": {
     "lib": "lib"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/agent_filters/namedinput_validator_agent_filter/package.json
+++ b/agent_filters/namedinput_validator_agent_filter/package.json
@@ -12,7 +12,8 @@
     "format": "prettier --write '{src,tests}/**/*.ts'",
     "test": "node --test --require ts-node/register ./tests/test_*.ts",
     "doc": "echo nothing",
-    "b": "yarn run format && yarn run eslint && yarn run build"
+    "b": "yarn run format && yarn run eslint && yarn run build",
+    "prepack": "yarn build"
   },
   "repository": {
     "type": "git",
@@ -31,5 +32,8 @@
   "types": "./lib/index.d.ts",
   "directories": {
     "lib": "lib"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/agent_filters/step_runner_agent_filter/package.json
+++ b/agent_filters/step_runner_agent_filter/package.json
@@ -13,7 +13,8 @@
     "test": "echo nothing",
     "test_run": "npx ts-node tests/run_step_runner.ts",
     "doc": "echo nothing",
-    "b": "yarn run format && yarn run eslint && yarn run build"
+    "b": "yarn run format && yarn run eslint && yarn run build",
+    "prepack": "yarn build"
   },
   "repository": {
     "type": "git",
@@ -32,5 +33,8 @@
   "types": "./lib/index.d.ts",
   "directories": {
     "lib": "lib"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/agent_filters/stream_agent_filter/package.json
+++ b/agent_filters/stream_agent_filter/package.json
@@ -8,8 +8,12 @@
   ],
   "typesVersions": {
     "*": {
-      "console": ["lib/console.d.ts"],
-      "node": ["lib/node.d.ts"]
+      "console": [
+        "lib/console.d.ts"
+      ],
+      "node": [
+        "lib/node.d.ts"
+      ]
     }
   },
   "exports": {
@@ -36,7 +40,8 @@
     "format": "prettier --write '{src,tests}/**/*.ts'",
     "test": "node --test  --require ts-node/register ./tests/test_*.ts",
     "doc": "echo nothing",
-    "b": "yarn run format && yarn run eslint && yarn run build"
+    "b": "yarn run format && yarn run eslint && yarn run build",
+    "prepack": "yarn build"
   },
   "repository": {
     "type": "git",
@@ -53,5 +58,8 @@
   "types": "./lib/index.d.ts",
   "directories": {
     "lib": "lib"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/agent_filters/utils/package.json
+++ b/agent_filters/utils/package.json
@@ -12,7 +12,8 @@
     "format": "prettier --write '{src,tests}/**/*.ts'",
     "test": "node --test --require ts-node/register ./tests/test_*.ts",
     "doc": "echo nothing",
-    "b": "yarn run format && yarn run eslint && yarn run build"
+    "b": "yarn run format && yarn run eslint && yarn run build",
+    "prepack": "yarn build"
   },
   "repository": {
     "type": "git",
@@ -29,5 +30,8 @@
   "types": "./lib/index.d.ts",
   "directories": {
     "lib": "lib"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/agents/agent_utils/package.json
+++ b/agents/agent_utils/package.json
@@ -12,7 +12,8 @@
     "format": "prettier --write '{src,tests}/**/*.ts'",
     "doc": "echo nothing",
     "test": "node --test --require ts-node/register ./tests/test_*.ts",
-    "b": "yarn run format && yarn run eslint && yarn run build"
+    "b": "yarn run format && yarn run eslint && yarn run build",
+    "prepack": "yarn build"
   },
   "repository": {
     "type": "git",
@@ -28,5 +29,8 @@
   "types": "./lib/index.d.ts",
   "directories": {
     "lib": "lib"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/agents/data_agents/package.json
+++ b/agents/data_agents/package.json
@@ -12,7 +12,8 @@
     "eslint": "eslint",
     "format": "prettier --write '{src,tests}/**/*.ts'",
     "test": "node --test --require ts-node/register ./tests/test_*.ts",
-    "b": "yarn run format && yarn run eslint && yarn run build"
+    "b": "yarn run format && yarn run eslint && yarn run build",
+    "prepack": "yarn build"
   },
   "repository": {
     "type": "git",
@@ -31,5 +32,8 @@
   "types": "./lib/index.d.ts",
   "directories": {
     "lib": "lib"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/agents/input_agents/package.json
+++ b/agents/input_agents/package.json
@@ -13,7 +13,8 @@
     "format": "prettier --write '{src,tests}/**/*.ts'",
     "test": "echo nothing",
     "test_run": "node --require ts-node/register ./test/run_agent.ts",
-    "b": "yarn run format && yarn run eslint && yarn run build"
+    "b": "yarn run format && yarn run eslint && yarn run build",
+    "prepack": "yarn build"
   },
   "repository": {
     "type": "git",
@@ -32,5 +33,8 @@
   "types": "./lib/index.d.ts",
   "directories": {
     "lib": "lib"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/agents/llm_agents/package.json
+++ b/agents/llm_agents/package.json
@@ -13,7 +13,8 @@
     "doc": "npx agentdoc",
     "test": "echo nothing",
     "b": "yarn run format && yarn run eslint && yarn run build",
-    "sample": "npx ts-node"
+    "sample": "npx ts-node",
+    "prepack": "yarn build"
   },
   "repository": {
     "type": "git",
@@ -37,5 +38,8 @@
   "types": "./lib/index.d.ts",
   "directories": {
     "lib": "lib"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/agents/service_agents/package.json
+++ b/agents/service_agents/package.json
@@ -13,7 +13,8 @@
     "examplesDoc": "npx ts-node tests/examples.ts",
     "format": "prettier --write '{src,tests}/**/*.ts'",
     "test": "node --test --require ts-node/register ./tests/test_*.ts",
-    "b": "yarn run format && yarn run eslint && yarn run build"
+    "b": "yarn run format && yarn run eslint && yarn run build",
+    "prepack": "yarn build"
   },
   "repository": {
     "type": "git",
@@ -34,5 +35,8 @@
   "types": "./lib/index.d.ts",
   "directories": {
     "lib": "lib"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/agents/sleeper_agents/package.json
+++ b/agents/sleeper_agents/package.json
@@ -12,7 +12,8 @@
     "eslint": "eslint",
     "format": "prettier --write '{src,tests}/**/*.ts'",
     "test": "node --test --require ts-node/register ./tests/test_*.ts",
-    "b": "yarn run format && yarn run eslint && yarn run build"
+    "b": "yarn run format && yarn run eslint && yarn run build",
+    "prepack": "yarn build"
   },
   "repository": {
     "type": "git",
@@ -31,5 +32,8 @@
   "types": "./lib/index.d.ts",
   "directories": {
     "lib": "lib"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/agents/vanilla_agents/package.json
+++ b/agents/vanilla_agents/package.json
@@ -15,7 +15,8 @@
     "test": "node --test --require ts-node/register ./tests/**/test_*.ts",
     "http_test": "node --test --require ts-node/register ./tests/**/http_*.ts",
     "b": "yarn run format && yarn run eslint && yarn run build",
-    "sample": "npx ts-node"
+    "sample": "npx ts-node",
+    "prepack": "yarn build"
   },
   "repository": {
     "type": "git",
@@ -33,5 +34,8 @@
   "types": "./lib/index.d.ts",
   "directories": {
     "lib": "lib"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/agents/vanilla_node_agents/package.json
+++ b/agents/vanilla_node_agents/package.json
@@ -14,7 +14,8 @@
     "test": "node --test --require ts-node/register ./tests/**/test_*.ts",
     "http_test": "node --test --require ts-node/register ./tests/**/http_*.ts",
     "b": "yarn run format && yarn run eslint && yarn run build",
-    "sample": "npx ts-node"
+    "sample": "npx ts-node",
+    "prepack": "yarn build"
   },
   "repository": {
     "type": "git",
@@ -32,5 +33,8 @@
   "types": "./lib/index.d.ts",
   "directories": {
     "lib": "lib"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/llm_agents/anthropic_agent/package.json
+++ b/llm_agents/anthropic_agent/package.json
@@ -14,7 +14,8 @@
     "examplesDoc": "npx ts-node  tests/examples.ts",
     "test": "node --test  --require ts-node/register ./tests/test_*.ts",
     "test_run": "node --test --require ts-node/register ./tests/run_*.ts # just run locally",
-    "b": "yarn run format && yarn run eslint && yarn run build"
+    "b": "yarn run format && yarn run eslint && yarn run build",
+    "prepack": "yarn build"
   },
   "repository": {
     "type": "git",
@@ -35,5 +36,8 @@
   "types": "./lib/index.d.ts",
   "directories": {
     "lib": "lib"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/llm_agents/gemini_agent/package.json
+++ b/llm_agents/gemini_agent/package.json
@@ -14,7 +14,8 @@
     "examplesDoc": "npx ts-node  tests/examples.ts",
     "test": "echo hello",
     "test_run": "node --test  --require ts-node/register ./tests/run_*.ts # just run locally",
-    "b": "yarn run format && yarn run eslint && yarn run build"
+    "b": "yarn run format && yarn run eslint && yarn run build",
+    "prepack": "yarn build"
   },
   "repository": {
     "type": "git",
@@ -34,5 +35,8 @@
   "types": "./lib/index.d.ts",
   "directories": {
     "lib": "lib"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/llm_agents/groq_agent/package.json
+++ b/llm_agents/groq_agent/package.json
@@ -14,7 +14,8 @@
     "examplesDoc": "npx ts-node  tests/examples.ts",
     "test": "echo hello",
     "test_run": "node --test  --require ts-node/register ./tests/run_*.ts # just run locally",
-    "b": "yarn run format && yarn run eslint && yarn run build"
+    "b": "yarn run format && yarn run eslint && yarn run build",
+    "prepack": "yarn build"
   },
   "repository": {
     "type": "git",
@@ -33,5 +34,8 @@
   "types": "./lib/index.d.ts",
   "directories": {
     "lib": "lib"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/llm_agents/llm_utils/package.json
+++ b/llm_agents/llm_utils/package.json
@@ -12,7 +12,8 @@
     "format": "prettier --write '{src,tests}/**/*.ts'",
     "doc": "echo nothing",
     "test": "node --test  --require ts-node/register ./tests/test_*.ts",
-    "b": "yarn run format && yarn run eslint && yarn run build"
+    "b": "yarn run format && yarn run eslint && yarn run build",
+    "prepack": "yarn build"
   },
   "repository": {
     "type": "git",
@@ -29,5 +30,8 @@
   "types": "./lib/index.d.ts",
   "directories": {
     "lib": "lib"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/llm_agents/openai_agent/package.json
+++ b/llm_agents/openai_agent/package.json
@@ -15,7 +15,8 @@
     "test": "echo nothing",
     "test_run": "node --test  --require ts-node/register ./tests/run_*.ts # just run locally",
     "chat": "node -r ts-node/register ./tests/chat_dispatch.ts",
-    "b": "yarn run format && yarn run eslint && yarn run build"
+    "b": "yarn run format && yarn run eslint && yarn run build",
+    "prepack": "yarn build"
   },
   "repository": {
     "type": "git",
@@ -35,5 +36,8 @@
   "types": "./lib/index.d.ts",
   "directories": {
     "lib": "lib"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/llm_agents/openai_fetch_agent/package.json
+++ b/llm_agents/openai_fetch_agent/package.json
@@ -15,7 +15,8 @@
     "test": "echo nothing",
     "test_run": "node --test  --require ts-node/register ./tests/run_*.ts # just run locally",
     "chat": "node -r ts-node/register ./tests/chat_dispatch.ts",
-    "b": "yarn run format && yarn run eslint && yarn run build"
+    "b": "yarn run format && yarn run eslint && yarn run build",
+    "prepack": "yarn build"
   },
   "repository": {
     "type": "git",
@@ -34,5 +35,8 @@
   "types": "./lib/index.d.ts",
   "directories": {
     "lib": "lib"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/llm_agents/playground/package.json
+++ b/llm_agents/playground/package.json
@@ -15,7 +15,8 @@
     "test": "node --test --require ts-node/register ./tests/test_*.ts",
     "test_run": "node --test  --require ts-node/register ./tests/run_*.ts # just run locally",
     "chat": "echo nothing",
-    "b": "echo nothing"
+    "b": "echo nothing",
+    "prepack": "yarn build"
   },
   "repository": {
     "type": "git",
@@ -32,5 +33,8 @@
   "types": "./lib/index.d.ts",
   "directories": {
     "lib": "lib"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/llm_agents/replicate_agent/package.json
+++ b/llm_agents/replicate_agent/package.json
@@ -14,7 +14,8 @@
     "examplesDoc": "npx ts-node  tests/examples.ts",
     "test": "echo nothing",
     "test_run": "node --test  --require ts-node/register ./tests/run_*.ts # just run locally",
-    "b": "yarn run format && yarn run eslint && yarn run build"
+    "b": "yarn run format && yarn run eslint && yarn run build",
+    "prepack": "yarn build"
   },
   "repository": {
     "type": "git",
@@ -34,5 +35,8 @@
   "types": "./lib/index.d.ts",
   "directories": {
     "lib": "lib"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/llm_agents/slashgpt_agent/package.json
+++ b/llm_agents/slashgpt_agent/package.json
@@ -13,7 +13,8 @@
     "doc": "npx agentdoc",
     "test": "echo hello",
     "test_run": "node --test  --require ts-node/register ./tests/run_*.ts # just run locally",
-    "b": "yarn run format && yarn run eslint && yarn run build"
+    "b": "yarn run format && yarn run eslint && yarn run build",
+    "prepack": "yarn build"
   },
   "repository": {
     "type": "git",
@@ -32,5 +33,8 @@
   "types": "./lib/index.d.ts",
   "directories": {
     "lib": "lib"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/llm_agents/token_bound_string_agent/package.json
+++ b/llm_agents/token_bound_string_agent/package.json
@@ -12,7 +12,8 @@
     "format": "prettier --write '{src,tests}/**/*.ts'",
     "doc": "npx agentdoc",
     "test": "node --test  --require ts-node/register ./tests/test_*.ts",
-    "b": "yarn run format && yarn run eslint && yarn run build"
+    "b": "yarn run format && yarn run eslint && yarn run build",
+    "prepack": "yarn build"
   },
   "repository": {
     "type": "git",
@@ -31,5 +32,8 @@
   "types": "./lib/index.d.ts",
   "directories": {
     "lib": "lib"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/llm_agents/tools_agent/package.json
+++ b/llm_agents/tools_agent/package.json
@@ -15,7 +15,8 @@
     "test": "node --test --require ts-node/register ./tests/test_*.ts",
     "test_run": "node --test  --require ts-node/register ./tests/run_*.ts # just run locally",
     "chat": "node -r ts-node/register ./tests/chat_dispatch.ts",
-    "b": "yarn run format && yarn run eslint && yarn run build"
+    "b": "yarn run format && yarn run eslint && yarn run build",
+    "prepack": "yarn build"
   },
   "repository": {
     "type": "git",
@@ -32,5 +33,8 @@
   "types": "./lib/index.d.ts",
   "directories": {
     "lib": "lib"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/packages/agent_filters/package.json
+++ b/packages/agent_filters/package.json
@@ -13,7 +13,8 @@
     "test": "echo nothing",
     "doc": "echo nothing",
     "http_server": "npx ts-node tests/express/server.ts",
-    "b": "yarn run format && yarn run eslint && yarn run build"
+    "b": "yarn run format && yarn run eslint && yarn run build",
+    "prepack": "yarn build"
   },
   "repository": {
     "type": "git",
@@ -42,5 +43,8 @@
   "types": "./lib/index.d.ts",
   "directories": {
     "lib": "lib"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/packages/agentdoc/package.json
+++ b/packages/agentdoc/package.json
@@ -17,7 +17,8 @@
     "format": "prettier --write '{src,test_yaml}/**/*.{yaml,ts,json}'",
     "doc": "echo nothing",
     "test": "node --test --require ts-node/register ./tests/test_*.ts",
-    "b": "yarn run format && yarn run eslint && yarn run build"
+    "b": "yarn run format && yarn run eslint && yarn run build",
+    "prepack": "yarn build"
   },
   "repository": {
     "type": "git",
@@ -38,5 +39,8 @@
     "lib": "lib",
     "template": "template",
     "mono_templates": "./mono_templates"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/packages/agents/package.json
+++ b/packages/agents/package.json
@@ -14,7 +14,8 @@
     "format": "prettier --write '{src,tests}/**/*.ts'",
     "test": "node --test --require ts-node/register ./tests/**/test_*.ts",
     "http_test": "node --test --require ts-node/register ./tests/**/http_*.ts",
-    "b": "yarn run format && yarn run eslint && yarn run build"
+    "b": "yarn run format && yarn run eslint && yarn run build",
+    "prepack": "yarn build"
   },
   "repository": {
     "type": "git",
@@ -38,5 +39,8 @@
   "types": "./lib/index.d.ts",
   "directories": {
     "lib": "lib"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -18,7 +18,8 @@
     "test_sh": "./scripts/test.sh",
     "test_node": "node --test --require ts-node/register ./test_yaml/test_*.ts",
     "cli": "node --require ts-node/register ./src/graphai_cli.ts",
-    "b": "yarn run format && yarn run eslint && yarn run build"
+    "b": "yarn run format && yarn run eslint && yarn run build",
+    "prepack": "yarn build"
   },
   "repository": {
     "type": "git",
@@ -46,5 +47,8 @@
   "types": "./lib/graphai_cli.d.ts",
   "directories": {
     "lib": "lib"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/packages/graphai/package.json
+++ b/packages/graphai/package.json
@@ -14,7 +14,8 @@
     "doc": "echo nothing",
     "format": "prettier --write '{src,tests}/**/*.ts' *.mjs",
     "test": "node --test --require ts-node/register ./tests/**/test_*.ts",
-    "b": "yarn run format && yarn run eslint && yarn run build"
+    "b": "yarn run format && yarn run eslint && yarn run build",
+    "prepack": "yarn build"
   },
   "repository": {
     "type": "git",
@@ -34,5 +35,8 @@
   "directories": {
     "lib": "lib",
     "test": "tests"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/packages/lite/package.json
+++ b/packages/lite/package.json
@@ -11,7 +11,8 @@
     "eslint": "eslint",
     "test": "node --test --require ts-node/register ./tests/test_*.ts",
     "doc": "echo nothing",
-    "format": "prettier --write '{src,tests,samples}/**/*.ts'"
+    "format": "prettier --write '{src,tests,samples}/**/*.ts'",
+    "prepack": "yarn build"
   },
   "repository": {
     "type": "git",
@@ -26,5 +27,8 @@
   "types": "./lib/index.d.ts",
   "directories": {
     "lib": "lib"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/packages/samples/package.json
+++ b/packages/samples/package.json
@@ -14,7 +14,8 @@
     "b": "yarn run format && yarn run eslint && yarn run build",
     "doc": "yarn run sample src/toYamlSample.ts",
     "samples": "npx ts-node src/sample_runner.ts",
-    "sample": "npx ts-node"
+    "sample": "npx ts-node",
+    "prepack": "yarn build"
   },
   "repository": {
     "type": "git",
@@ -35,5 +36,8 @@
   "directories": {
     "lib": "lib",
     "test": "tests"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/packages/test_utils/package.json
+++ b/packages/test_utils/package.json
@@ -12,7 +12,8 @@
     "test": "echo hello",
     "doc": "echo nothing",
     "format": "prettier --write 'src/**/*.ts'",
-    "b": "yarn run format && yarn run eslint && yarn run build"
+    "b": "yarn run format && yarn run eslint && yarn run build",
+    "prepack": "yarn build"
   },
   "repository": {
     "type": "git",
@@ -35,5 +36,8 @@
   "types": "./lib/index.d.ts",
   "directories": {
     "lib": "lib"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/plans/chore-prepack-publishconfig.md
+++ b/plans/chore-prepack-publishconfig.md
@@ -1,0 +1,52 @@
+# chore: add `prepack` and `publishConfig` to all publishable packages
+
+## User Prompt
+
+> npm の publish 時の設定  prepack で yarn build → lib/ 生成 → publishConfig で lib/ が参照される流れです。 を全てで追加できる？
+>
+> B案（lib/ のまま、prepack と publishConfig だけ追加）で、ブランチを作って進めて。
+
+## Goal
+
+Standardize the publish flow across every workspace package so that:
+
+- `npm publish` / `yarn npm publish` always re-builds the package via `prepack` before packaging, guaranteeing a fresh `lib/` artifact.
+- `publishConfig` is set so that scoped packages are published as public without needing the `--access public` flag in the release command.
+
+Keep the existing `lib/` output path (do **not** migrate to `dist/`).
+
+## Scope
+
+Apply to all 33 workspace packages discovered under:
+
+- `packages/*`
+- `agents/*`
+- `agent_filters/*`
+- `llm_agents/*`
+
+## Changes per package.json
+
+1. Add to `scripts`:
+   ```json
+   "prepack": "yarn build"
+   ```
+2. Add top-level:
+   ```json
+   "publishConfig": {
+     "access": "public"
+   }
+   ```
+
+No changes to `main`, `types`, `files`, `directories`, or `tsconfig` — `lib/` stays as the output target.
+
+## Non-goals
+
+- No switch to `dist/`.
+- No change to the per-package `build` scripts (some packages use `rm -r lib/* && tsc`, others `tsc`, others `echo nothing`).
+- No change to the monorepo release process docs in `CLAUDE.md` beyond what is already accurate (`npm publish --access public` continues to work; `--access public` becomes redundant once `publishConfig` is in place, but is not harmful).
+
+## Validation
+
+- `yarn format`
+- `yarn eslint`
+- `yarn build`


### PR DESCRIPTION
## Summary

- Adds `"prepack": "yarn build"` to every workspace package's `scripts` so that `npm publish` / `yarn pack` always regenerates `lib/` before the tarball is assembled.
- Adds top-level `"publishConfig": { "access": "public" }` to every workspace package so `npm publish --access public` is no longer required at the CLI for scoped packages.
- Keeps `lib/` as the build output (no migration to `dist/`).
- Affects **33 package.json files** across `packages/`, `agents/`, `agent_filters/`, and `llm_agents/`.
- Adds `plans/chore-prepack-publishconfig.md` per the repo's bug-fix / feature-request workflow.

## Items to Confirm / Review

1. **`prepack` semantics** — the hook runs on both `npm pack` and `npm publish`, and also on `yarn pack` (verified locally with `yarn pack --dry-run` in `packages/graphai`). If the release process currently assumes a pre-built `lib/`, this change no-ops; if it assumed _no_ build, the extra build is the intended fix.
2. **No `private: true` packages** — every workspace package was treated as publishable. None were marked private, including `packages/samples` and `llm_agents/playground` whose `build` scripts are `echo nothing`. For those, `prepack` effectively does nothing, which is harmless.
3. **Non-scoped `graphai` package** — `publishConfig.access: "public"` is valid but technically redundant for the unscoped `graphai` package. Left in for uniformity; can be removed if preferred.
4. **Release docs in `CLAUDE.md`** — `npm publish --access public` still works; `--access public` is now redundant but not harmful. Docs not updated in this PR — flag if you'd like that follow-up.

## User Prompt

> npm の publish 時の設定、`prepack` で `yarn build` → `lib/` 生成 → `publishConfig` で `lib/` が参照される流れです。これを全てのパッケージで追加できる？
>
> （当初は `dist/` と書いてあったがコピペミスで、正しくは `lib/`）
>
> B案（`lib/` のまま、`prepack` と `publishConfig` だけ追加する最小変更）で、ブランチを作って進めて。PRも作ってほしい。

## Implementation

Per-file change (all 33 package.json files):

```diff
   "scripts": {
     …existing scripts…,
+    "prepack": "yarn build"
   },
   …
+  "publishConfig": {
+    "access": "public"
+  }
```

Applied mechanically via a one-shot Node script that parsed/serialized each `package.json` preserving existing key order (script deleted before commit).

## Validation

- [x] `yarn format` — clean
- [x] `yarn build` — all 33 packages built successfully
- [x] `yarn pack --dry-run` in `packages/graphai` — confirms `prepack` → `yarn build` runs before tarball creation
- [ ] `yarn eslint` — one pre-existing error in the **untracked** file `packages/agentdoc/tests/schema2doc.ts`; unrelated to this PR (reproduces on `main`)

## Test plan

- [ ] CI passes on this PR
- [ ] On next package release, confirm `npm publish` (or `yarn npm publish`) triggers `yarn build` automatically via `prepack`
- [ ] Confirm `publishConfig.access` is honored by the registry (no `--access public` needed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)