### PR TITLE
feat: concurrency per label with head-of-line skip (#1304)

### DIFF
--- a/packages/graphai/src/graphai.ts
+++ b/packages/graphai/src/graphai.ts
@@ -151,9 +151,15 @@ export class GraphAI {
     this.graphId = `${Date.now().toString(36)}-${Math.random().toString(36).substr(2, 9)}`; // URL.createObjectURL(new Blob()).slice(-36);
     this.agentFunctionInfoDictionary = agentFunctionInfoDictionary;
     this.propFunctions = propFunctions;
+    this.bypassAgentIds = options.bypassAgentIds ?? [];
+
+    // Validate before constructing TaskManager so user-facing ValidationError
+    // is reported instead of TaskManager's internal guard message.
+    validateGraphData(graphData, [...Object.keys(agentFunctionInfoDictionary), ...this.bypassAgentIds]);
+    validateAgent(agentFunctionInfoDictionary);
+
     this.taskManager = options.taskManager ?? new TaskManager(graphData.concurrency ?? defaultConcurrency);
     this.agentFilters = options.agentFilters ?? [];
-    this.bypassAgentIds = options.bypassAgentIds ?? [];
     this.config = options.config;
     this.graphLoader = options.graphLoader;
     this.forceLoop = options.forceLoop ?? false;
@@ -163,9 +169,6 @@ export class GraphAI {
     this.onComplete = (__isAbort: boolean) => {
       throw new Error("SOMETHING IS WRONG: onComplete is called without run()");
     };
-
-    validateGraphData(graphData, [...Object.keys(agentFunctionInfoDictionary), ...this.bypassAgentIds]);
-    validateAgent(agentFunctionInfoDictionary);
 
     this.graphData = {
       ...graphData,

--- a/packages/graphai/src/node.ts
+++ b/packages/graphai/src/node.ts
@@ -348,30 +348,37 @@ export class ComputedNode extends Node {
       const localLog: TransactionLog[] = [];
       const context = this.getContext(previousResults, localLog, agentId, config);
 
-      // NOTE: We use the existence of graph object in the agent-specific params to determine
-      // if this is a nested agent or not.
-      if (hasNestedGraph) {
-        this.graph.taskManager.prepareForNesting(this.label);
-        context.forNestedGraph = {
-          graphData: this.nestedGraph
-            ? "nodes" in this.nestedGraph
-              ? this.nestedGraph
-              : (this.graph.resultOf(this.nestedGraph) as GraphData) // HACK: compiler work-around
-            : { version: 0, nodes: {} },
-          agents: this.graph.agentFunctionInfoDictionary,
-          graphOptions: {
-            agentFilters: this.graph.agentFilters,
-            taskManager: this.graph.taskManager,
-            bypassAgentIds: this.graph.bypassAgentIds,
-            config,
-            graphLoader: this.graph.graphLoader,
-          },
-          onLogCallback: this.graph.onLogCallback,
-          callbacks: this.graph.callbacks,
-        };
-      }
-
+      // The `nestingPrepared` flag tracks whether prepareForNesting has actually
+      // run. If anything throws between prepareForNesting and the agent call --
+      // e.g. resultOf() during forNestedGraph construction -- we still need to
+      // restore. Conversely, if prepareForNesting itself throws, we must NOT
+      // restore (no bump to undo).
+      let nestingPrepared = false;
       try {
+        // NOTE: We use the existence of graph object in the agent-specific params to determine
+        // if this is a nested agent or not.
+        if (hasNestedGraph) {
+          this.graph.taskManager.prepareForNesting(this.label);
+          nestingPrepared = true;
+          context.forNestedGraph = {
+            graphData: this.nestedGraph
+              ? "nodes" in this.nestedGraph
+                ? this.nestedGraph
+                : (this.graph.resultOf(this.nestedGraph) as GraphData) // HACK: compiler work-around
+              : { version: 0, nodes: {} },
+            agents: this.graph.agentFunctionInfoDictionary,
+            graphOptions: {
+              agentFilters: this.graph.agentFilters,
+              taskManager: this.graph.taskManager,
+              bypassAgentIds: this.graph.bypassAgentIds,
+              config,
+              graphLoader: this.graph.graphLoader,
+            },
+            onLogCallback: this.graph.onLogCallback,
+            callbacks: this.graph.callbacks,
+          };
+        }
+
         this.beforeConsoleLog(context);
         const result = await this.agentFilterHandler(context as AgentFunctionContext, agentFunction, agentId);
         this.afterConsoleLog(result);
@@ -395,9 +402,7 @@ export class ComputedNode extends Node {
         // after process
         this.afterExecute(result, localLog);
       } finally {
-        // Always release the nesting bump, even when the nested execution throws,
-        // so the shared TaskManager's global/label slots cannot leak.
-        if (hasNestedGraph) {
+        if (nestingPrepared) {
           this.graph.taskManager.restoreAfterNesting(this.label);
         }
       }

--- a/packages/graphai/src/node.ts
+++ b/packages/graphai/src/node.ts
@@ -119,7 +119,10 @@ export class ComputedNode extends Node {
     this.timeout = data.timeout;
     this.isResult = data.isResult ?? false;
     this.priority = data.priority ?? 0;
-    this.label = data.label;
+    // Defensive: graph data may originate from YAML/JSON without strict typing.
+    // Keep label only when it is actually a string so TaskManager's label-keyed
+    // bookkeeping cannot be silently bypassed by a non-string value.
+    this.label = typeof data.label === "string" ? data.label : undefined;
 
     assert(["function", "string"].includes(typeof data.agent), "agent must be either string or function");
     if (typeof data.agent === "string") {
@@ -348,7 +351,7 @@ export class ComputedNode extends Node {
       // NOTE: We use the existence of graph object in the agent-specific params to determine
       // if this is a nested agent or not.
       if (hasNestedGraph) {
-        this.graph.taskManager.prepareForNesting();
+        this.graph.taskManager.prepareForNesting(this.label);
         context.forNestedGraph = {
           graphData: this.nestedGraph
             ? "nodes" in this.nestedGraph
@@ -373,7 +376,7 @@ export class ComputedNode extends Node {
       this.afterConsoleLog(result);
 
       if (hasNestedGraph) {
-        this.graph.taskManager.restoreAfterNesting();
+        this.graph.taskManager.restoreAfterNesting(this.label);
       }
 
       if (!this.isCurrentTransaction(transactionId)) {

--- a/packages/graphai/src/node.ts
+++ b/packages/graphai/src/node.ts
@@ -358,7 +358,7 @@ export class ComputedNode extends Node {
         // NOTE: We use the existence of graph object in the agent-specific params to determine
         // if this is a nested agent or not.
         if (hasNestedGraph) {
-          this.graph.taskManager.prepareForNesting(this.label);
+          this.graph.taskManager.prepareForNesting(this.label, this.graphId);
           nestingPrepared = true;
           context.forNestedGraph = {
             graphData: this.nestedGraph
@@ -403,7 +403,7 @@ export class ComputedNode extends Node {
         this.afterExecute(result, localLog);
       } finally {
         if (nestingPrepared) {
-          this.graph.taskManager.restoreAfterNesting(this.label);
+          this.graph.taskManager.restoreAfterNesting(this.label, this.graphId);
         }
       }
     } catch (error) {

--- a/packages/graphai/src/node.ts
+++ b/packages/graphai/src/node.ts
@@ -89,6 +89,7 @@ export class ComputedNode extends Node {
   private agentFunction?: AgentFunction<any, any, any, any>;
   public readonly timeout?: number; // msec
   public readonly priority: number;
+  public readonly label?: string;
   public error?: Error;
   public transactionId: undefined | number; // To reject callbacks from timed-out transactions
   private readonly passThrough?: PassThrough;
@@ -118,6 +119,7 @@ export class ComputedNode extends Node {
     this.timeout = data.timeout;
     this.isResult = data.isResult ?? false;
     this.priority = data.priority ?? 0;
+    this.label = data.label;
 
     assert(["function", "string"].includes(typeof data.agent), "agent must be either string or function");
     if (typeof data.agent === "string") {

--- a/packages/graphai/src/node.ts
+++ b/packages/graphai/src/node.ts
@@ -371,32 +371,36 @@ export class ComputedNode extends Node {
         };
       }
 
-      this.beforeConsoleLog(context);
-      const result = await this.agentFilterHandler(context as AgentFunctionContext, agentFunction, agentId);
-      this.afterConsoleLog(result);
+      try {
+        this.beforeConsoleLog(context);
+        const result = await this.agentFilterHandler(context as AgentFunctionContext, agentFunction, agentId);
+        this.afterConsoleLog(result);
 
-      if (hasNestedGraph) {
-        this.graph.taskManager.restoreAfterNesting(this.label);
-      }
-
-      if (!this.isCurrentTransaction(transactionId)) {
-        // This condition happens when the agent function returns
-        // after the timeout (either retried or not).
-        GraphAILogger.log(`-- transactionId mismatch with ${this.nodeId} (probably timeout)`);
-        return;
-      }
-
-      if (this.repeatUntil?.exists) {
-        const dummyResult = { self: { result: this.getResult(result) } as unknown as ComputedNode };
-        const repeatResult = resultsOf({ data: this.repeatUntil?.exists }, dummyResult, [], true);
-        if (isNull(repeatResult?.data)) {
-          this.retry(NodeState.Failed, Error("Repeat Until"));
+        if (!this.isCurrentTransaction(transactionId)) {
+          // This condition happens when the agent function returns
+          // after the timeout (either retried or not).
+          GraphAILogger.log(`-- transactionId mismatch with ${this.nodeId} (probably timeout)`);
           return;
         }
-      }
 
-      // after process
-      this.afterExecute(result, localLog);
+        if (this.repeatUntil?.exists) {
+          const dummyResult = { self: { result: this.getResult(result) } as unknown as ComputedNode };
+          const repeatResult = resultsOf({ data: this.repeatUntil?.exists }, dummyResult, [], true);
+          if (isNull(repeatResult?.data)) {
+            this.retry(NodeState.Failed, Error("Repeat Until"));
+            return;
+          }
+        }
+
+        // after process
+        this.afterExecute(result, localLog);
+      } finally {
+        // Always release the nesting bump, even when the nested execution throws,
+        // so the shared TaskManager's global/label slots cannot leak.
+        if (hasNestedGraph) {
+          this.graph.taskManager.restoreAfterNesting(this.label);
+        }
+      }
     } catch (error) {
       this.errorProcess(error, transactionId, previousResults);
     }

--- a/packages/graphai/src/task_manager.ts
+++ b/packages/graphai/src/task_manager.ts
@@ -24,6 +24,11 @@ export class TaskManager {
   private concurrency: number;
   private labelLimits: Map<string, number>;
   private runningByLabel: Map<string, number> = new Map();
+  // Per-label bypass capacity granted to nested children. Keyed by parentGraphId
+  // so that only tasks whose graphId differs from the parent (i.e. those running
+  // inside the nested graph) can consume the extra slot. Unrelated siblings on
+  // the same graphId as the parent are not affected.
+  private nestingBypassByLabel: Map<string, Map<string, number>> = new Map();
   private taskQueue: Array<TaskEntry> = [];
   private runningNodes = new Set<ComputedNode>();
 
@@ -48,7 +53,24 @@ export class TaskManager {
       return true;
     }
     const running = this.runningByLabel.get(label) ?? 0;
-    return running < limit;
+    if (running < limit) {
+      return true;
+    }
+    // Bypass path: if a labeled parent has prepared for nesting and this task
+    // belongs to a different graph (i.e. the nested graph), grant +1 per such
+    // outstanding bump. Unrelated siblings on the parent's graphId do NOT get
+    // this allowance, so the per-label cap is preserved for them.
+    const bypass = this.nestingBypassByLabel.get(label);
+    if (!bypass) {
+      return false;
+    }
+    let extra = 0;
+    for (const [parentGraphId, count] of bypass) {
+      if (parentGraphId !== task.graphId) {
+        extra += count;
+      }
+    }
+    return running < limit + extra;
   }
 
   // Walk the queue (already sorted by priority desc) and dispatch the first task
@@ -120,21 +142,47 @@ export class TaskManager {
   // to a nested agent. We need to make it sure that there is enough room to run
   // computed nodes inside the nested graph to avoid a deadlock.
   //
-  // When the parent node carries a label that has a configured per-label limit,
-  // bumping the global slot alone is not enough: a nested-graph child sharing
-  // that label would still be blocked by the parent's own slot, leading to a
-  // deadlock. Bump that label's limit too while we're nested.
-  public prepareForNesting(label?: string) {
+  // When the parent carries a label that has a configured per-label limit,
+  // a nested child sharing that label would otherwise stay queued forever
+  // (parent waits for child, child blocked by parent's label slot). To avoid
+  // this without widening the cap for unrelated siblings, we record a per-
+  // parent-graphId bypass that canRun() applies only to tasks whose graphId
+  // differs from the parent's.
+  public prepareForNesting(label?: string, parentGraphId?: string) {
     this.concurrency++;
-    if (label !== undefined && this.labelLimits.has(label)) {
-      this.labelLimits.set(label, (this.labelLimits.get(label) ?? 0) + 1);
+    if (label !== undefined && parentGraphId !== undefined && this.labelLimits.has(label)) {
+      let perParent = this.nestingBypassByLabel.get(label);
+      if (!perParent) {
+        perParent = new Map();
+        this.nestingBypassByLabel.set(label, perParent);
+      }
+      perParent.set(parentGraphId, (perParent.get(parentGraphId) ?? 0) + 1);
+    }
+    // Both the global slot bump and the optional label bypass can free capacity
+    // for already-queued tasks; drain the queue while progress is being made.
+    let progressed = true;
+    while (progressed) {
+      const before = this.runningNodes.size;
+      this.dequeueTaskIfPossible();
+      progressed = this.runningNodes.size > before;
     }
   }
 
-  public restoreAfterNesting(label?: string) {
+  public restoreAfterNesting(label?: string, parentGraphId?: string) {
     this.concurrency--;
-    if (label !== undefined && this.labelLimits.has(label)) {
-      this.labelLimits.set(label, (this.labelLimits.get(label) ?? 0) - 1);
+    if (label !== undefined && parentGraphId !== undefined) {
+      const perParent = this.nestingBypassByLabel.get(label);
+      if (perParent) {
+        const next = (perParent.get(parentGraphId) ?? 0) - 1;
+        if (next <= 0) {
+          perParent.delete(parentGraphId);
+        } else {
+          perParent.set(parentGraphId, next);
+        }
+        if (perParent.size === 0) {
+          this.nestingBypassByLabel.delete(label);
+        }
+      }
     }
   }
 
@@ -154,5 +202,6 @@ export class TaskManager {
     this.taskQueue.length = 0;
     this.runningNodes.clear();
     this.runningByLabel.clear();
+    this.nestingBypassByLabel.clear();
   }
 }

--- a/packages/graphai/src/task_manager.ts
+++ b/packages/graphai/src/task_manager.ts
@@ -1,6 +1,6 @@
 import { ComputedNode } from "./node";
 import { ConcurrencyConfig } from "./type";
-import { assert, isObject } from "./utils/utils";
+import { assert, isPlainObject } from "./utils/utils";
 
 type TaskEntry = {
   node: ComputedNode;
@@ -8,12 +8,35 @@ type TaskEntry = {
   callback: (node: ComputedNode) => void;
 };
 
+const assertPositiveInteger = (value: unknown, field: string): number => {
+  if (typeof value !== "number" || !Number.isInteger(value) || value < 1) {
+    throw new Error(`TaskManager: ${field} must be a positive integer (got ${String(value)})`);
+  }
+  return value;
+};
+
+// Mirrors the strictness of validateConcurrencyConfig() so that direct
+// `new TaskManager(...)` calls (e.g. tests, advanced consumers that bypass
+// validateGraphData) cannot silently disable label enforcement with a
+// malformed shape such as Map / Date / class instances / arrays.
 const normalizeConcurrencyConfig = (config: number | ConcurrencyConfig): { global: number; labels: Map<string, number> } => {
   if (typeof config === "number") {
-    return { global: config, labels: new Map() };
+    return { global: assertPositiveInteger(config, "concurrency"), labels: new Map() };
   }
-  const labelsObj = isObject<number>(config.labels) ? config.labels : {};
-  return { global: config.global, labels: new Map(Object.entries(labelsObj)) };
+  if (!isPlainObject(config)) {
+    throw new Error("TaskManager: concurrency must be a positive integer or a ConcurrencyConfig object");
+  }
+  const global = assertPositiveInteger(config.global, "concurrency.global");
+  const labels = new Map<string, number>();
+  if (config.labels !== undefined) {
+    if (!isPlainObject(config.labels)) {
+      throw new Error("TaskManager: concurrency.labels must be a plain object");
+    }
+    for (const [labelKey, labelValue] of Object.entries(config.labels)) {
+      labels.set(labelKey, assertPositiveInteger(labelValue, `concurrency.labels.${labelKey}`));
+    }
+  }
+  return { global, labels };
 };
 
 // TaskManage object controls the concurrency of ComputedNode execution.

--- a/packages/graphai/src/task_manager.ts
+++ b/packages/graphai/src/task_manager.ts
@@ -1,6 +1,6 @@
 import { ComputedNode } from "./node";
 import { ConcurrencyConfig } from "./type";
-import { assert } from "./utils/utils";
+import { assert, isObject } from "./utils/utils";
 
 type TaskEntry = {
   node: ComputedNode;
@@ -12,7 +12,8 @@ const normalizeConcurrencyConfig = (config: number | ConcurrencyConfig): { globa
   if (typeof config === "number") {
     return { global: config, labels: new Map() };
   }
-  return { global: config.global, labels: new Map(Object.entries(config.labels ?? {})) };
+  const labelsObj = isObject<number>(config.labels) ? config.labels : {};
+  return { global: config.global, labels: new Map(Object.entries(labelsObj)) };
 };
 
 // TaskManage object controls the concurrency of ComputedNode execution.
@@ -118,12 +119,23 @@ export class TaskManager {
   // Node will call this method before it hands the task manager from the graph
   // to a nested agent. We need to make it sure that there is enough room to run
   // computed nodes inside the nested graph to avoid a deadlock.
-  public prepareForNesting() {
+  //
+  // When the parent node carries a label that has a configured per-label limit,
+  // bumping the global slot alone is not enough: a nested-graph child sharing
+  // that label would still be blocked by the parent's own slot, leading to a
+  // deadlock. Bump that label's limit too while we're nested.
+  public prepareForNesting(label?: string) {
     this.concurrency++;
+    if (label !== undefined && this.labelLimits.has(label)) {
+      this.labelLimits.set(label, (this.labelLimits.get(label) ?? 0) + 1);
+    }
   }
 
-  public restoreAfterNesting() {
+  public restoreAfterNesting(label?: string) {
     this.concurrency--;
+    if (label !== undefined && this.labelLimits.has(label)) {
+      this.labelLimits.set(label, (this.labelLimits.get(label) ?? 0) - 1);
+    }
   }
 
   public getStatus(verbose: boolean = false) {

--- a/packages/graphai/src/task_manager.ts
+++ b/packages/graphai/src/task_manager.ts
@@ -1,4 +1,5 @@
 import { ComputedNode } from "./node";
+import { ConcurrencyConfig } from "./type";
 import { assert } from "./utils/utils";
 
 type TaskEntry = {
@@ -7,28 +8,65 @@ type TaskEntry = {
   callback: (node: ComputedNode) => void;
 };
 
+const normalizeConcurrencyConfig = (config: number | ConcurrencyConfig): { global: number; labels: Map<string, number> } => {
+  if (typeof config === "number") {
+    return { global: config, labels: new Map() };
+  }
+  return { global: config.global, labels: new Map(Object.entries(config.labels ?? {})) };
+};
+
 // TaskManage object controls the concurrency of ComputedNode execution.
 //
 // NOTE: A TaskManager instance will be shared between parent graph and its children
 // when nested agents are involved.
 export class TaskManager {
   private concurrency: number;
+  private labelLimits: Map<string, number>;
+  private runningByLabel: Map<string, number> = new Map();
   private taskQueue: Array<TaskEntry> = [];
   private runningNodes = new Set<ComputedNode>();
 
-  constructor(concurrency: number) {
-    this.concurrency = concurrency;
+  constructor(config: number | ConcurrencyConfig) {
+    const normalized = normalizeConcurrencyConfig(config);
+    this.concurrency = normalized.global;
+    this.labelLimits = normalized.labels;
   }
 
-  // This internal method dequeus a task from the task queue
-  // and call the associated callback method, if the number of
-  // running task is lower than the spcified limit.
+  // Returns true if the task can run right now under both the global limit
+  // and (if specified) its label-specific limit.
+  private canRun(task: TaskEntry): boolean {
+    if (this.runningNodes.size >= this.concurrency) {
+      return false;
+    }
+    const label = task.node.label;
+    if (label === undefined) {
+      return true;
+    }
+    const limit = this.labelLimits.get(label);
+    if (limit === undefined) {
+      return true;
+    }
+    const running = this.runningByLabel.get(label) ?? 0;
+    return running < limit;
+  }
+
+  // Walk the queue (already sorted by priority desc) and dispatch the first task
+  // whose label still has capacity. This is the "head-of-line skip" policy.
   private dequeueTaskIfPossible() {
-    if (this.runningNodes.size < this.concurrency) {
-      const task = this.taskQueue.shift();
-      if (task) {
+    if (this.runningNodes.size >= this.concurrency) {
+      return;
+    }
+    for (let i = 0; i < this.taskQueue.length; i++) {
+      const task = this.taskQueue[i];
+      if (this.canRun(task)) {
+        this.taskQueue.splice(i, 1);
         this.runningNodes.add(task.node);
+        const label = task.node.label;
+        if (label !== undefined) {
+          this.runningByLabel.set(label, (this.runningByLabel.get(label) ?? 0) + 1);
+        }
         task.callback(task.node);
+        return;
       }
     }
   }
@@ -36,7 +74,7 @@ export class TaskManager {
   // Node will call this method to put itself in the execution queue.
   // We call the associated callback function when it is dequeued.
   public addTask(node: ComputedNode, graphId: string, callback: (node: ComputedNode) => void) {
-    // Finder tasks in the queue, which has either the same or higher priority.
+    // Find tasks in the queue, which has either the same or higher priority.
     const count = this.taskQueue.filter((task) => {
       return task.node.priority >= node.priority;
     }).length;
@@ -57,7 +95,24 @@ export class TaskManager {
   public onComplete(node: ComputedNode) {
     assert(this.runningNodes.has(node), `TaskManager.onComplete node(${node.nodeId}) is not in list`);
     this.runningNodes.delete(node);
-    this.dequeueTaskIfPossible();
+    const label = node.label;
+    if (label !== undefined) {
+      const running = this.runningByLabel.get(label) ?? 0;
+      if (running <= 1) {
+        this.runningByLabel.delete(label);
+      } else {
+        this.runningByLabel.set(label, running - 1);
+      }
+    }
+    // A label slot may have just opened, so try to dispatch as many newly-eligible
+    // tasks as possible (the freed label could allow several queued tasks to run if
+    // the global limit is not yet reached).
+    let progressed = true;
+    while (progressed) {
+      const before = this.runningNodes.size;
+      this.dequeueTaskIfPossible();
+      progressed = this.runningNodes.size > before;
+    }
   }
 
   // Node will call this method before it hands the task manager from the graph
@@ -86,5 +141,6 @@ export class TaskManager {
   public reset() {
     this.taskQueue.length = 0;
     this.runningNodes.clear();
+    this.runningByLabel.clear();
   }
 }

--- a/packages/graphai/src/type.ts
+++ b/packages/graphai/src/type.ts
@@ -70,6 +70,7 @@ export type ComputedNodeData = {
   graphLoader?: GraphDataLoaderOption;
   isResult?: boolean;
   priority?: number; // The default is 0.
+  label?: string; // optional concurrency-control bucket key. unspecified -> not subject to per-label limits.
   passThrough?: PassThrough; // data that pass trough to result
   console?: ConsoleElement;
 };
@@ -81,10 +82,15 @@ export type LoopData = {
   while?: string | boolean;
 };
 
+export type ConcurrencyConfig = {
+  global: number;
+  labels?: Record<string, number>;
+};
+
 export type GraphData = {
   version?: number; // major version, 0.1, 0.2, ...
   nodes: Record<string, NodeData>;
-  concurrency?: number;
+  concurrency?: number | ConcurrencyConfig;
   loop?: LoopData;
   verbose?: boolean;
   retry?: number;

--- a/packages/graphai/src/utils/utils.ts
+++ b/packages/graphai/src/utils/utils.ts
@@ -51,6 +51,16 @@ export const isObject = <Values = unknown>(x: unknown): x is Record<string, Valu
   return x !== null && typeof x === "object";
 };
 
+// Stricter than isObject: rejects arrays, Map, Date, class instances, etc., that
+// would otherwise pass `typeof === "object"` and confuse `Object.entries()`.
+// Realm-sensitive (compares against the current realm's Object.prototype),
+// which is fine for graph data sourced from JSON.parse or in-process construction.
+export const isPlainObject = <Values = unknown>(x: unknown): x is Record<string, Values> => {
+  if (!isObject(x) || Array.isArray(x)) return false;
+  const proto = Object.getPrototypeOf(x);
+  return proto === null || proto === Object.prototype;
+};
+
 export const isNull = (data: unknown) => {
   return data === null || data === undefined;
 };

--- a/packages/graphai/src/validators/common.ts
+++ b/packages/graphai/src/validators/common.ts
@@ -13,6 +13,7 @@ export const computedNodeAttributeKeys = [
   "graphLoader",
   "isResult",
   "priority",
+  "label",
   "if",
   "unless",
   "defaultValue",

--- a/packages/graphai/src/validators/computed_node_validator.ts
+++ b/packages/graphai/src/validators/computed_node_validator.ts
@@ -7,5 +7,8 @@ export const computedNodeValidator = (nodeData: ComputedNodeData) => {
       throw new ValidationError("Computed node does not allow " + key);
     }
   });
+  if (nodeData.label !== undefined && typeof nodeData.label !== "string") {
+    throw new ValidationError("Computed node label must be a string");
+  }
   return true;
 };

--- a/packages/graphai/src/validators/graph_data_validator.ts
+++ b/packages/graphai/src/validators/graph_data_validator.ts
@@ -1,5 +1,6 @@
 import { GraphData, ConcurrencyConfig } from "../type";
 import { graphDataAttributeKeys, ValidationError } from "./common";
+import { isObject, isNull } from "../utils/utils";
 
 const validateConcurrencyValue = (value: unknown, fieldDescription: string) => {
   if (!Number.isInteger(value)) {
@@ -15,15 +16,15 @@ const validateConcurrencyConfig = (concurrency: number | ConcurrencyConfig) => {
     validateConcurrencyValue(concurrency, "Concurrency");
     return;
   }
-  if (typeof concurrency !== "object" || concurrency === null || Array.isArray(concurrency)) {
+  if (!isObject(concurrency) || Array.isArray(concurrency)) {
     throw new ValidationError("Concurrency must be an integer");
   }
   if (!("global" in concurrency)) {
     throw new ValidationError("Concurrency object must have a global field");
   }
   validateConcurrencyValue(concurrency.global, "Concurrency.global");
-  if (concurrency.labels !== undefined) {
-    if (typeof concurrency.labels !== "object" || concurrency.labels === null || Array.isArray(concurrency.labels)) {
+  if (!isNull(concurrency.labels)) {
+    if (!isObject(concurrency.labels) || Array.isArray(concurrency.labels)) {
       throw new ValidationError("Concurrency.labels must be an object");
     }
     for (const [labelKey, labelValue] of Object.entries(concurrency.labels)) {

--- a/packages/graphai/src/validators/graph_data_validator.ts
+++ b/packages/graphai/src/validators/graph_data_validator.ts
@@ -1,6 +1,6 @@
 import { GraphData, ConcurrencyConfig } from "../type";
 import { graphDataAttributeKeys, ValidationError } from "./common";
-import { isObject, isNull } from "../utils/utils";
+import { isObject } from "../utils/utils";
 
 const validateConcurrencyValue = (value: unknown, fieldDescription: string) => {
   if (!Number.isInteger(value)) {
@@ -23,7 +23,9 @@ const validateConcurrencyConfig = (concurrency: number | ConcurrencyConfig) => {
     throw new ValidationError("Concurrency object must have a global field");
   }
   validateConcurrencyValue(concurrency.global, "Concurrency.global");
-  if (!isNull(concurrency.labels)) {
+  // The schema declares labels?: Record<string, number>. undefined is the only
+  // sentinel for "absent"; null and other non-plain-object shapes are malformed.
+  if (concurrency.labels !== undefined) {
     if (!isObject(concurrency.labels) || Array.isArray(concurrency.labels)) {
       throw new ValidationError("Concurrency.labels must be an object");
     }

--- a/packages/graphai/src/validators/graph_data_validator.ts
+++ b/packages/graphai/src/validators/graph_data_validator.ts
@@ -1,14 +1,6 @@
 import { GraphData, ConcurrencyConfig } from "../type";
 import { graphDataAttributeKeys, ValidationError } from "./common";
-import { isObject } from "../utils/utils";
-
-// Plain-object check: rejects arrays, Map, Date, class instances, etc., that
-// would otherwise pass `typeof === "object"` and confuse Object.entries().
-const isPlainObject = (x: unknown): x is Record<string, unknown> => {
-  if (!isObject(x) || Array.isArray(x)) return false;
-  const proto = Object.getPrototypeOf(x);
-  return proto === null || proto === Object.prototype;
-};
+import { isPlainObject } from "../utils/utils";
 
 const concurrencyConfigKeys: ReadonlyArray<keyof ConcurrencyConfig> = ["global", "labels"];
 

--- a/packages/graphai/src/validators/graph_data_validator.ts
+++ b/packages/graphai/src/validators/graph_data_validator.ts
@@ -1,5 +1,36 @@
-import { GraphData } from "../type";
+import { GraphData, ConcurrencyConfig } from "../type";
 import { graphDataAttributeKeys, ValidationError } from "./common";
+
+const validateConcurrencyValue = (value: unknown, fieldDescription: string) => {
+  if (!Number.isInteger(value)) {
+    throw new ValidationError(`${fieldDescription} must be an integer`);
+  }
+  if ((value as number) < 1) {
+    throw new ValidationError(`${fieldDescription} must be a positive integer`);
+  }
+};
+
+const validateConcurrencyConfig = (concurrency: number | ConcurrencyConfig) => {
+  if (typeof concurrency === "number") {
+    validateConcurrencyValue(concurrency, "Concurrency");
+    return;
+  }
+  if (typeof concurrency !== "object" || concurrency === null || Array.isArray(concurrency)) {
+    throw new ValidationError("Concurrency must be an integer");
+  }
+  if (!("global" in concurrency)) {
+    throw new ValidationError("Concurrency object must have a global field");
+  }
+  validateConcurrencyValue(concurrency.global, "Concurrency.global");
+  if (concurrency.labels !== undefined) {
+    if (typeof concurrency.labels !== "object" || concurrency.labels === null || Array.isArray(concurrency.labels)) {
+      throw new ValidationError("Concurrency.labels must be an object");
+    }
+    for (const [labelKey, labelValue] of Object.entries(concurrency.labels)) {
+      validateConcurrencyValue(labelValue, `Concurrency.labels.${labelKey}`);
+    }
+  }
+};
 
 export const graphNodesValidator = (data: GraphData) => {
   if (data.nodes === undefined) {
@@ -30,11 +61,6 @@ export const graphDataValidator = (data: GraphData) => {
     }
   }
   if (data.concurrency !== undefined) {
-    if (!Number.isInteger(data.concurrency)) {
-      throw new ValidationError("Concurrency must be an integer");
-    }
-    if (data.concurrency < 1) {
-      throw new ValidationError("Concurrency must be a positive integer");
-    }
+    validateConcurrencyConfig(data.concurrency);
   }
 };

--- a/packages/graphai/src/validators/graph_data_validator.ts
+++ b/packages/graphai/src/validators/graph_data_validator.ts
@@ -2,11 +2,21 @@ import { GraphData, ConcurrencyConfig } from "../type";
 import { graphDataAttributeKeys, ValidationError } from "./common";
 import { isObject } from "../utils/utils";
 
+// Plain-object check: rejects arrays, Map, Date, class instances, etc., that
+// would otherwise pass `typeof === "object"` and confuse Object.entries().
+const isPlainObject = (x: unknown): x is Record<string, unknown> => {
+  if (!isObject(x) || Array.isArray(x)) return false;
+  const proto = Object.getPrototypeOf(x);
+  return proto === null || proto === Object.prototype;
+};
+
+const concurrencyConfigKeys: ReadonlyArray<keyof ConcurrencyConfig> = ["global", "labels"];
+
 const validateConcurrencyValue = (value: unknown, fieldDescription: string) => {
-  if (!Number.isInteger(value)) {
+  if (typeof value !== "number" || !Number.isInteger(value)) {
     throw new ValidationError(`${fieldDescription} must be an integer`);
   }
-  if ((value as number) < 1) {
+  if (value < 1) {
     throw new ValidationError(`${fieldDescription} must be a positive integer`);
   }
 };
@@ -16,17 +26,24 @@ const validateConcurrencyConfig = (concurrency: number | ConcurrencyConfig) => {
     validateConcurrencyValue(concurrency, "Concurrency");
     return;
   }
-  if (!isObject(concurrency) || Array.isArray(concurrency)) {
+  if (!isPlainObject(concurrency)) {
     throw new ValidationError("Concurrency must be an integer");
+  }
+  for (const key of Object.keys(concurrency)) {
+    if (!concurrencyConfigKeys.includes(key as keyof ConcurrencyConfig)) {
+      throw new ValidationError(`Concurrency object does not allow ${key}`);
+    }
   }
   if (!("global" in concurrency)) {
     throw new ValidationError("Concurrency object must have a global field");
   }
   validateConcurrencyValue(concurrency.global, "Concurrency.global");
   // The schema declares labels?: Record<string, number>. undefined is the only
-  // sentinel for "absent"; null and other non-plain-object shapes are malformed.
+  // sentinel for "absent"; null, arrays, Maps, Dates and other non-plain-object
+  // shapes are malformed and would silently disable label enforcement (their
+  // Object.entries() yields no string keys).
   if (concurrency.labels !== undefined) {
-    if (!isObject(concurrency.labels) || Array.isArray(concurrency.labels)) {
+    if (!isPlainObject(concurrency.labels)) {
       throw new ValidationError("Concurrency.labels must be an object");
     }
     for (const [labelKey, labelValue] of Object.entries(concurrency.labels)) {

--- a/packages/graphai/tests/units/test_task_manager.ts
+++ b/packages/graphai/tests/units/test_task_manager.ts
@@ -346,7 +346,9 @@ test("TaskManager prepareForNesting bumps label limit when nested parent is labe
   // Scenario: parent task with label 'openai' (limit 1) is currently running
   // and triggers a nested graph whose child also wants label 'openai'. Without
   // the label-aware bump, the child would queue forever -> deadlock.
-  const tm = new TaskManager({ global: 1, labels: { openai: 1 } });
+  // Use global=2 so the label decrement (not the global one) is the binding
+  // constraint for the post-restore tasks below.
+  const tm = new TaskManager({ global: 2, labels: { openai: 1 } });
   const { executed, callback } = collectExecutionOrder();
 
   const parent = makeNode("parent", 0, "g1", "openai");
@@ -363,9 +365,21 @@ test("TaskManager prepareForNesting bumps label limit when nested parent is labe
 
   tm.onComplete(child);
   tm.restoreAfterNesting("openai");
+  tm.onComplete(parent);
 
-  // Capacity should be back to original.
-  assert.equal(tm.getStatus().concurrency, 1);
+  // Global capacity should be back to original.
+  assert.equal(tm.getStatus().concurrency, 2);
+
+  // Critically: confirm the label decrement was symmetric. With global=2 and
+  // openai limit back to 1, scheduling two openai tasks must produce only one
+  // running and one queued. A broken label decrement would leave the bump in
+  // place (limit=2) and let both run -- the global limit (2) would not catch it.
+  const post: string[] = [];
+  const postCallback = (n: ComputedNode) => post.push(n.nodeId);
+  tm.addTask(makeNode("post1", 0, "g1", "openai"), "g1", postCallback);
+  tm.addTask(makeNode("post2", 0, "g1", "openai"), "g1", postCallback);
+  assert.deepStrictEqual(post, ["post1"]);
+  assert.equal(tm.getStatus().queue, 1);
 });
 
 test("TaskManager prepareForNesting without label keeps existing behavior", () => {

--- a/packages/graphai/tests/units/test_task_manager.ts
+++ b/packages/graphai/tests/units/test_task_manager.ts
@@ -341,3 +341,49 @@ test("TaskManager reset clears per-label running state", () => {
   tm.addTask(makeNode("o2", 0, "g1", "openai"), "g1", (n) => after.push(n.nodeId));
   assert.deepStrictEqual(after, ["o2"]);
 });
+
+test("TaskManager prepareForNesting bumps label limit when nested parent is labeled", () => {
+  // Scenario: parent task with label 'openai' (limit 1) is currently running
+  // and triggers a nested graph whose child also wants label 'openai'. Without
+  // the label-aware bump, the child would queue forever -> deadlock.
+  const tm = new TaskManager({ global: 1, labels: { openai: 1 } });
+  const { executed, callback } = collectExecutionOrder();
+
+  const parent = makeNode("parent", 0, "g1", "openai");
+  tm.addTask(parent, "g1", callback);
+  assert.deepStrictEqual(executed, ["parent"]);
+
+  // Parent is about to invoke nested graph: bump capacity for itself.
+  tm.prepareForNesting("openai");
+
+  // Now a nested child sharing the same label should be runnable.
+  const child = makeNode("child", 0, "g1", "openai");
+  tm.addTask(child, "g1", callback);
+  assert.deepStrictEqual(executed, ["parent", "child"]);
+
+  tm.onComplete(child);
+  tm.restoreAfterNesting("openai");
+
+  // Capacity should be back to original.
+  assert.equal(tm.getStatus().concurrency, 1);
+});
+
+test("TaskManager prepareForNesting without label keeps existing behavior", () => {
+  const tm = new TaskManager({ global: 1, labels: { openai: 1 } });
+  tm.prepareForNesting();
+  assert.equal(tm.getStatus().concurrency, 2);
+  tm.restoreAfterNesting();
+  assert.equal(tm.getStatus().concurrency, 1);
+});
+
+test("TaskManager prepareForNesting with unconfigured label only bumps global", () => {
+  const tm = new TaskManager({ global: 1, labels: { openai: 1 } });
+  tm.prepareForNesting("untracked");
+  assert.equal(tm.getStatus().concurrency, 2);
+  // openai limit untouched (still 1)
+  const { executed, callback } = collectExecutionOrder();
+  tm.addTask(makeNode("a", 0, "g1", "openai"), "g1", callback);
+  tm.addTask(makeNode("b", 0, "g1", "openai"), "g1", callback);
+  assert.deepStrictEqual(executed, ["a"]); // 'b' blocked by openai's still-1 limit
+  tm.restoreAfterNesting("untracked");
+});

--- a/packages/graphai/tests/units/test_task_manager.ts
+++ b/packages/graphai/tests/units/test_task_manager.ts
@@ -1,0 +1,343 @@
+import { TaskManager } from "../../src/task_manager";
+import { ComputedNode } from "../../src/node";
+
+import test from "node:test";
+import assert from "node:assert";
+
+type Stub = { nodeId: string; graphId: string; priority: number; label?: string };
+const makeNode = (nodeId: string, priority = 0, graphId = "g1", label?: string): ComputedNode => {
+  const stub: Stub = { nodeId, graphId, priority, label };
+  return stub as unknown as ComputedNode;
+};
+
+const collectExecutionOrder = () => {
+  const executed: string[] = [];
+  const callback = (node: ComputedNode) => {
+    executed.push(node.nodeId);
+  };
+  return { executed, callback };
+};
+
+test("TaskManager runs tasks immediately when concurrency available", () => {
+  const tm = new TaskManager(3);
+  const { executed, callback } = collectExecutionOrder();
+
+  tm.addTask(makeNode("a"), "g1", callback);
+  tm.addTask(makeNode("b"), "g1", callback);
+
+  assert.deepStrictEqual(executed, ["a", "b"]);
+  const status = tm.getStatus();
+  assert.equal(status.running, 2);
+  assert.equal(status.queue, 0);
+});
+
+test("TaskManager queues tasks beyond concurrency limit", () => {
+  const tm = new TaskManager(2);
+  const { executed, callback } = collectExecutionOrder();
+
+  const a = makeNode("a");
+  const b = makeNode("b");
+  const c = makeNode("c");
+  const d = makeNode("d");
+
+  tm.addTask(a, "g1", callback);
+  tm.addTask(b, "g1", callback);
+  tm.addTask(c, "g1", callback);
+  tm.addTask(d, "g1", callback);
+
+  assert.deepStrictEqual(executed, ["a", "b"]);
+  assert.equal(tm.getStatus().queue, 2);
+  assert.equal(tm.getStatus().running, 2);
+});
+
+test("TaskManager dequeues next task on completion (FIFO within same priority)", () => {
+  const tm = new TaskManager(2);
+  const { executed, callback } = collectExecutionOrder();
+
+  const a = makeNode("a");
+  const b = makeNode("b");
+  const c = makeNode("c");
+  const d = makeNode("d");
+
+  tm.addTask(a, "g1", callback);
+  tm.addTask(b, "g1", callback);
+  tm.addTask(c, "g1", callback);
+  tm.addTask(d, "g1", callback);
+
+  tm.onComplete(a);
+  assert.deepStrictEqual(executed, ["a", "b", "c"]);
+
+  tm.onComplete(b);
+  assert.deepStrictEqual(executed, ["a", "b", "c", "d"]);
+
+  assert.equal(tm.getStatus().queue, 0);
+  assert.equal(tm.getStatus().running, 2);
+});
+
+test("TaskManager dequeues higher priority first", () => {
+  const tm = new TaskManager(1);
+  const { executed, callback } = collectExecutionOrder();
+
+  const a = makeNode("a", 0); // executes immediately
+  const low = makeNode("low", 1);
+  const high = makeNode("high", 10);
+  const mid = makeNode("mid", 5);
+
+  tm.addTask(a, "g1", callback);
+  tm.addTask(low, "g1", callback);
+  tm.addTask(high, "g1", callback);
+  tm.addTask(mid, "g1", callback);
+
+  assert.deepStrictEqual(executed, ["a"]);
+
+  tm.onComplete(a);
+  assert.deepStrictEqual(executed, ["a", "high"]);
+
+  tm.onComplete(high);
+  assert.deepStrictEqual(executed, ["a", "high", "mid"]);
+
+  tm.onComplete(mid);
+  assert.deepStrictEqual(executed, ["a", "high", "mid", "low"]);
+});
+
+test("TaskManager preserves FIFO order for tasks with equal priority", () => {
+  const tm = new TaskManager(1);
+  const { executed, callback } = collectExecutionOrder();
+
+  const first = makeNode("first");
+  const a = makeNode("a", 5);
+  const b = makeNode("b", 5);
+  const c = makeNode("c", 5);
+
+  tm.addTask(first, "g1", callback);
+  tm.addTask(a, "g1", callback);
+  tm.addTask(b, "g1", callback);
+  tm.addTask(c, "g1", callback);
+
+  tm.onComplete(first);
+  tm.onComplete(a);
+  tm.onComplete(b);
+
+  assert.deepStrictEqual(executed, ["first", "a", "b", "c"]);
+});
+
+test("TaskManager isRunning detects running and queued tasks per graphId", () => {
+  const tm = new TaskManager(1);
+  const { callback } = collectExecutionOrder();
+
+  const a = makeNode("a", 0, "graphA");
+  const b = makeNode("b", 0, "graphB"); // queued
+
+  tm.addTask(a, "graphA", callback);
+  tm.addTask(b, "graphB", callback);
+
+  assert.equal(tm.isRunning("graphA"), true);
+  assert.equal(tm.isRunning("graphB"), true); // queued counts as running per current impl
+  assert.equal(tm.isRunning("graphC"), false);
+
+  tm.onComplete(a);
+  assert.equal(tm.isRunning("graphA"), false);
+  assert.equal(tm.isRunning("graphB"), true);
+
+  tm.onComplete(b);
+  assert.equal(tm.isRunning("graphB"), false);
+});
+
+test("TaskManager prepareForNesting / restoreAfterNesting bumps capacity", () => {
+  const tm = new TaskManager(1);
+  const { executed, callback } = collectExecutionOrder();
+
+  tm.addTask(makeNode("a"), "g1", callback);
+  assert.equal(tm.getStatus().running, 1);
+  assert.equal(tm.getStatus().concurrency, 1);
+
+  // prepareForNesting raises capacity but does not retroactively dequeue.
+  // The next addTask is what will succeed because the limit is now higher.
+  tm.prepareForNesting();
+  assert.equal(tm.getStatus().concurrency, 2);
+
+  tm.addTask(makeNode("b"), "g1", callback);
+  assert.deepStrictEqual(executed, ["a", "b"]);
+
+  tm.restoreAfterNesting();
+  assert.equal(tm.getStatus().concurrency, 1);
+});
+
+test("TaskManager getStatus reports verbose node ids when requested", () => {
+  const tm = new TaskManager(1);
+  const { callback } = collectExecutionOrder();
+
+  tm.addTask(makeNode("running"), "g1", callback);
+  tm.addTask(makeNode("queued"), "g1", callback);
+
+  const status = tm.getStatus(true) as { runningNodes: string[]; queuedNodes: string[] };
+  assert.deepStrictEqual(status.runningNodes, ["running"]);
+  assert.deepStrictEqual(status.queuedNodes, ["queued"]);
+});
+
+test("TaskManager reset clears queue and running set", () => {
+  const tm = new TaskManager(1);
+  const { callback } = collectExecutionOrder();
+
+  tm.addTask(makeNode("a"), "g1", callback);
+  tm.addTask(makeNode("b"), "g1", callback);
+
+  tm.reset();
+  assert.equal(tm.getStatus().running, 0);
+  assert.equal(tm.getStatus().queue, 0);
+  assert.equal(tm.isRunning("g1"), false);
+});
+
+// ---- label-based concurrency tests ----
+
+test("TaskManager accepts ConcurrencyConfig object form", () => {
+  const tm = new TaskManager({ global: 4, labels: { openai: 2 } });
+  const status = tm.getStatus();
+  assert.equal(status.concurrency, 4);
+});
+
+test("TaskManager enforces per-label concurrency limit", () => {
+  const tm = new TaskManager({ global: 10, labels: { openai: 2 } });
+  const { executed, callback } = collectExecutionOrder();
+
+  tm.addTask(makeNode("o1", 0, "g1", "openai"), "g1", callback);
+  tm.addTask(makeNode("o2", 0, "g1", "openai"), "g1", callback);
+  tm.addTask(makeNode("o3", 0, "g1", "openai"), "g1", callback);
+  tm.addTask(makeNode("o4", 0, "g1", "openai"), "g1", callback);
+
+  assert.deepStrictEqual(executed, ["o1", "o2"]);
+  assert.equal(tm.getStatus().queue, 2);
+});
+
+test("TaskManager dispatches different labels independently", () => {
+  const tm = new TaskManager({ global: 10, labels: { openai: 2, vertex: 1 } });
+  const { executed, callback } = collectExecutionOrder();
+
+  tm.addTask(makeNode("o1", 0, "g1", "openai"), "g1", callback);
+  tm.addTask(makeNode("o2", 0, "g1", "openai"), "g1", callback);
+  tm.addTask(makeNode("o3", 0, "g1", "openai"), "g1", callback);
+  tm.addTask(makeNode("v1", 0, "g1", "vertex"), "g1", callback);
+  tm.addTask(makeNode("v2", 0, "g1", "vertex"), "g1", callback);
+
+  // openai limit=2 -> o1,o2 run; o3 queued.
+  // vertex limit=1 -> v1 runs; v2 queued.
+  assert.deepStrictEqual(executed, ["o1", "o2", "v1"]);
+});
+
+test("TaskManager skips head-of-queue when its label is full (HoL skip)", () => {
+  const tm = new TaskManager({ global: 10, labels: { openai: 1 } });
+  const { executed, callback } = collectExecutionOrder();
+
+  // High-priority openai first -> runs immediately.
+  tm.addTask(makeNode("o-high", 10, "g1", "openai"), "g1", callback);
+  // Another high-priority openai blocked by label limit -> queued.
+  tm.addTask(makeNode("o-blocked", 9, "g1", "openai"), "g1", callback);
+  // Low-priority vertex (no limit) -> should be allowed to start because
+  // the head of queue (o-blocked) is starved by its label.
+  tm.addTask(makeNode("v-low", 1, "g1", "vertex"), "g1", callback);
+
+  assert.deepStrictEqual(executed, ["o-high", "v-low"]);
+  assert.equal(tm.getStatus().queue, 1);
+});
+
+test("TaskManager unlabeled tasks are not subject to label limits", () => {
+  const tm = new TaskManager({ global: 5, labels: { openai: 1 } });
+  const { executed, callback } = collectExecutionOrder();
+
+  tm.addTask(makeNode("o1", 0, "g1", "openai"), "g1", callback);
+  tm.addTask(makeNode("o2", 0, "g1", "openai"), "g1", callback); // blocked by label
+  tm.addTask(makeNode("plain1"), "g1", callback);
+  tm.addTask(makeNode("plain2"), "g1", callback);
+
+  // o1 runs, o2 queued, plain1/plain2 run unaffected by label limit.
+  assert.deepStrictEqual(executed, ["o1", "plain1", "plain2"]);
+});
+
+test("TaskManager labels not configured are not constrained", () => {
+  const tm = new TaskManager({ global: 5, labels: { openai: 1 } });
+  const { executed, callback } = collectExecutionOrder();
+
+  // 'untracked' label has no entry in labels map -> should run freely up to global.
+  tm.addTask(makeNode("u1", 0, "g1", "untracked"), "g1", callback);
+  tm.addTask(makeNode("u2", 0, "g1", "untracked"), "g1", callback);
+  tm.addTask(makeNode("u3", 0, "g1", "untracked"), "g1", callback);
+
+  assert.deepStrictEqual(executed, ["u1", "u2", "u3"]);
+});
+
+test("TaskManager onComplete frees label slot for queued tasks", () => {
+  const tm = new TaskManager({ global: 10, labels: { openai: 1 } });
+  const { executed, callback } = collectExecutionOrder();
+
+  const o1 = makeNode("o1", 0, "g1", "openai");
+  const o2 = makeNode("o2", 0, "g1", "openai");
+  const o3 = makeNode("o3", 0, "g1", "openai");
+
+  tm.addTask(o1, "g1", callback);
+  tm.addTask(o2, "g1", callback);
+  tm.addTask(o3, "g1", callback);
+  assert.deepStrictEqual(executed, ["o1"]);
+
+  tm.onComplete(o1);
+  assert.deepStrictEqual(executed, ["o1", "o2"]);
+
+  tm.onComplete(o2);
+  assert.deepStrictEqual(executed, ["o1", "o2", "o3"]);
+});
+
+test("TaskManager honors global limit even when label has capacity", () => {
+  const tm = new TaskManager({ global: 2, labels: { openai: 10 } });
+  const { executed, callback } = collectExecutionOrder();
+
+  tm.addTask(makeNode("o1", 0, "g1", "openai"), "g1", callback);
+  tm.addTask(makeNode("o2", 0, "g1", "openai"), "g1", callback);
+  tm.addTask(makeNode("o3", 0, "g1", "openai"), "g1", callback);
+
+  assert.deepStrictEqual(executed, ["o1", "o2"]);
+  assert.equal(tm.getStatus().queue, 1);
+});
+
+test("TaskManager onComplete dispatches as many newly-eligible tasks as the global limit allows", () => {
+  // Scenario: two labels each capped at 1, global capped at 3.
+  // Initial state fills openai=1 (running), but vertex tasks are queued because
+  // earlier head-of-queue tasks took slots. Releasing a global slot should
+  // dispatch multiple queued tasks if their labels allow.
+  const tm = new TaskManager({ global: 3, labels: { openai: 1, vertex: 1 } });
+  const { executed, callback } = collectExecutionOrder();
+
+  const o1 = makeNode("o1", 5, "g1", "openai");
+  const v1 = makeNode("v1", 4, "g1", "vertex");
+  const free1 = makeNode("free1", 3, "g1", "free"); // 'free' has no label limit
+  const free2 = makeNode("free2", 2, "g1", "free");
+  const free3 = makeNode("free3", 1, "g1", "free");
+
+  tm.addTask(o1, "g1", callback);
+  tm.addTask(v1, "g1", callback);
+  tm.addTask(free1, "g1", callback);
+  tm.addTask(free2, "g1", callback);
+  tm.addTask(free3, "g1", callback);
+
+  // global=3: o1, v1, free1 running. free2, free3 queued.
+  assert.deepStrictEqual(executed, ["o1", "v1", "free1"]);
+
+  tm.onComplete(o1);
+  // Frees a global slot AND openai label. Next eligible (priority order): free2.
+  // Should dispatch one (global was 2/3, now back to 3/3 after free2 starts).
+  assert.deepStrictEqual(executed, ["o1", "v1", "free1", "free2"]);
+
+  tm.onComplete(v1);
+  assert.deepStrictEqual(executed, ["o1", "v1", "free1", "free2", "free3"]);
+});
+
+test("TaskManager reset clears per-label running state", () => {
+  const tm = new TaskManager({ global: 10, labels: { openai: 1 } });
+  const { callback } = collectExecutionOrder();
+
+  tm.addTask(makeNode("o1", 0, "g1", "openai"), "g1", callback);
+  tm.reset();
+
+  // After reset, a new openai task should be allowed (label slot is free again).
+  const after: string[] = [];
+  tm.addTask(makeNode("o2", 0, "g1", "openai"), "g1", (n) => after.push(n.nodeId));
+  assert.deepStrictEqual(after, ["o2"]);
+});

--- a/packages/graphai/tests/units/test_task_manager.ts
+++ b/packages/graphai/tests/units/test_task_manager.ts
@@ -342,38 +342,53 @@ test("TaskManager reset clears per-label running state", () => {
   assert.deepStrictEqual(after, ["o2"]);
 });
 
-test("TaskManager prepareForNesting bumps label limit when nested parent is labeled", () => {
-  // Scenario: parent task with label 'openai' (limit 1) is currently running
-  // and triggers a nested graph whose child also wants label 'openai'. Without
-  // the label-aware bump, the child would queue forever -> deadlock.
-  // Use global=2 so the label decrement (not the global one) is the binding
-  // constraint for the post-restore tasks below.
-  const tm = new TaskManager({ global: 2, labels: { openai: 1 } });
+test("TaskManager nesting allows child on different graphId, blocks sibling on same graphId", () => {
+  // Realistic nested-graph scenario:
+  //   - Parent runs in outer graph "g1" with label "openai" (limit 1).
+  //   - Parent invokes a nested graph whose graphId is "nested-1" (different).
+  //   - The nested graph schedules a child task with the same label "openai".
+  //   - Meanwhile a separate sibling on graphId "g1" (the outer graph)
+  //     also wants label "openai".
+  //
+  // We want: nested child runs (otherwise deadlock); sibling does NOT run
+  // (otherwise the per-label cap is silently widened for unrelated work).
+  const tm = new TaskManager({ global: 5, labels: { openai: 1 } });
   const { executed, callback } = collectExecutionOrder();
 
   const parent = makeNode("parent", 0, "g1", "openai");
   tm.addTask(parent, "g1", callback);
   assert.deepStrictEqual(executed, ["parent"]);
 
-  // Parent is about to invoke nested graph: bump capacity for itself.
-  tm.prepareForNesting("openai");
+  // Parent invokes nested graph.
+  tm.prepareForNesting("openai", "g1");
 
-  // Now a nested child sharing the same label should be runnable.
-  const child = makeNode("child", 0, "g1", "openai");
-  tm.addTask(child, "g1", callback);
+  // Nested child arrives on a DIFFERENT graphId -> bypass applies.
+  const child = makeNode("child", 0, "nested-1", "openai");
+  tm.addTask(child, "nested-1", callback);
   assert.deepStrictEqual(executed, ["parent", "child"]);
 
+  // Unrelated sibling arrives on the parent's graphId -> bypass does NOT apply.
+  // It must be queued, not started, even though the global limit (5) has room.
+  const sibling = makeNode("sibling", 0, "g1", "openai");
+  tm.addTask(sibling, "g1", callback);
+  assert.deepStrictEqual(executed, ["parent", "child"]);
+  assert.equal(tm.getStatus().queue, 1);
+
+  // Tear down: child completes, then parent restores its nesting bump.
   tm.onComplete(child);
-  tm.restoreAfterNesting("openai");
+  tm.restoreAfterNesting("openai", "g1");
+
+  // After restore the bypass is gone. Parent still holds the openai slot,
+  // so the queued sibling should NOT have started yet.
+  assert.deepStrictEqual(executed, ["parent", "child"]);
+
+  // Parent finally completes -> sibling gets its slot.
   tm.onComplete(parent);
+  assert.deepStrictEqual(executed, ["parent", "child", "sibling"]);
 
-  // Global capacity should be back to original.
-  assert.equal(tm.getStatus().concurrency, 2);
-
-  // Critically: confirm the label decrement was symmetric. With global=2 and
-  // openai limit back to 1, scheduling two openai tasks must produce only one
-  // running and one queued. A broken label decrement would leave the bump in
-  // place (limit=2) and let both run -- the global limit (2) would not catch it.
+  // And the bookkeeping is fully unwound: a fresh openai task should run, a
+  // second one should queue (limit back to 1).
+  tm.onComplete(sibling);
   const post: string[] = [];
   const postCallback = (n: ComputedNode) => post.push(n.nodeId);
   tm.addTask(makeNode("post1", 0, "g1", "openai"), "g1", postCallback);
@@ -392,12 +407,23 @@ test("TaskManager prepareForNesting without label keeps existing behavior", () =
 
 test("TaskManager prepareForNesting with unconfigured label only bumps global", () => {
   const tm = new TaskManager({ global: 1, labels: { openai: 1 } });
-  tm.prepareForNesting("untracked");
+  tm.prepareForNesting("untracked", "g1");
   assert.equal(tm.getStatus().concurrency, 2);
-  // openai limit untouched (still 1)
+  // openai limit untouched -> a second openai task on a *different* graphId
+  // is still blocked because the bypass map has no entry for "openai".
   const { executed, callback } = collectExecutionOrder();
   tm.addTask(makeNode("a", 0, "g1", "openai"), "g1", callback);
-  tm.addTask(makeNode("b", 0, "g1", "openai"), "g1", callback);
-  assert.deepStrictEqual(executed, ["a"]); // 'b' blocked by openai's still-1 limit
-  tm.restoreAfterNesting("untracked");
+  tm.addTask(makeNode("b", 0, "nested-1", "openai"), "nested-1", callback);
+  assert.deepStrictEqual(executed, ["a"]);
+  tm.restoreAfterNesting("untracked", "g1");
 });
+
+// NOTE: there is a deliberate residual hole in the bypass model when two
+// completely independent top-level graphs share a TaskManager. In that case
+// the sibling-graphId distinction cannot tell "an unrelated independent
+// graph's task" from "my actual nested child", because both have a graphId
+// different from the parent's. GraphAI's documented usage is hierarchical
+// (parent -> nested child), not "two independent top-level graphs sharing a
+// TaskManager", so this is not exercised here. Tracking that case precisely
+// would require threading parent->child graphId binding through the GraphAI
+// constructor, which is out of scope for this PR.

--- a/packages/graphai/tests/units/test_task_manager.ts
+++ b/packages/graphai/tests/units/test_task_manager.ts
@@ -196,6 +196,42 @@ test("TaskManager accepts ConcurrencyConfig object form", () => {
   assert.equal(status.concurrency, 4);
 });
 
+// Direct-construction guards (consumers that bypass validateGraphData).
+test("TaskManager constructor rejects zero / negative concurrency", () => {
+  assert.throws(() => new TaskManager(0), /must be a positive integer/);
+  assert.throws(() => new TaskManager(-1), /must be a positive integer/);
+});
+
+test("TaskManager constructor rejects non-integer concurrency", () => {
+  assert.throws(() => new TaskManager(1.5), /must be a positive integer/);
+  assert.throws(() => new TaskManager("5" as unknown as number), /must be a positive integer/);
+});
+
+test("TaskManager constructor rejects malformed config object", () => {
+  assert.throws(() => new TaskManager(null as unknown as number), /must be a positive integer or a ConcurrencyConfig object/);
+  assert.throws(() => new TaskManager([] as unknown as number), /must be a positive integer or a ConcurrencyConfig object/);
+  assert.throws(() => new TaskManager(new Date() as unknown as number), /must be a positive integer or a ConcurrencyConfig object/);
+});
+
+test("TaskManager constructor rejects malformed labels (array silently became object indexes)", () => {
+  // The original concern: `labels: ["openai", 2]` would pass `typeof === "object"`,
+  // and Object.entries would yield bogus { "0": "openai", "1": 2 } pairs.
+  assert.throws(() => new TaskManager({ global: 5, labels: ["openai", 2] as unknown as Record<string, number> }), /labels must be a plain object/);
+});
+
+test("TaskManager constructor rejects malformed labels (Map / class instance)", () => {
+  assert.throws(() => new TaskManager({ global: 5, labels: new Map([["openai", 3]]) as unknown as Record<string, number> }), /labels must be a plain object/);
+  class Limits {
+    openai = 3;
+  }
+  assert.throws(() => new TaskManager({ global: 5, labels: new Limits() as unknown as Record<string, number> }), /labels must be a plain object/);
+});
+
+test("TaskManager constructor rejects malformed label value", () => {
+  assert.throws(() => new TaskManager({ global: 5, labels: { openai: "3" as unknown as number } }), /labels\.openai must be a positive integer/);
+  assert.throws(() => new TaskManager({ global: 5, labels: { openai: 0 } }), /labels\.openai must be a positive integer/);
+});
+
 test("TaskManager enforces per-label concurrency limit", () => {
   const tm = new TaskManager({ global: 10, labels: { openai: 2 } });
   const { executed, callback } = collectExecutionOrder();

--- a/packages/graphai/tests/validators/test_validator_computed_node.ts
+++ b/packages/graphai/tests/validators/test_validator_computed_node.ts
@@ -29,14 +29,51 @@ test("test static node validation value", async () => {
   await rejectTest(__dirname, graph_data, "Computed node does not allow update");
 });
 
-test("test computed node label must be a string", async () => {
+test("test computed node label must be a string (number)", async () => {
   const graph_data = anonymization({
     version: graphDataLatestVersion,
     nodes: {
-      computed1: {
-        agent: "echoAgent",
-        label: 5,
-      },
+      computed1: { agent: "echoAgent", label: 5 },
+    },
+  });
+  await rejectTest(__dirname, graph_data, "Computed node label must be a string");
+});
+
+test("test computed node label must be a string (null)", async () => {
+  const graph_data = anonymization({
+    version: graphDataLatestVersion,
+    nodes: {
+      computed1: { agent: "echoAgent", label: null },
+    },
+  });
+  await rejectTest(__dirname, graph_data, "Computed node label must be a string");
+});
+
+test("test computed node label must be a string (array)", async () => {
+  const graph_data = anonymization({
+    version: graphDataLatestVersion,
+    nodes: {
+      computed1: { agent: "echoAgent", label: ["openai"] },
+    },
+  });
+  await rejectTest(__dirname, graph_data, "Computed node label must be a string");
+});
+
+test("test computed node label must be a string (object)", async () => {
+  const graph_data = anonymization({
+    version: graphDataLatestVersion,
+    nodes: {
+      computed1: { agent: "echoAgent", label: { name: "openai" } },
+    },
+  });
+  await rejectTest(__dirname, graph_data, "Computed node label must be a string");
+});
+
+test("test computed node label must be a string (boolean)", async () => {
+  const graph_data = anonymization({
+    version: graphDataLatestVersion,
+    nodes: {
+      computed1: { agent: "echoAgent", label: true },
     },
   });
   await rejectTest(__dirname, graph_data, "Computed node label must be a string");
@@ -51,6 +88,17 @@ test("test computed node label string is valid", async () => {
         agent: "echoAgent",
         label: "openai",
       },
+    },
+  };
+  validateGraphData(graph_data, ["echoAgent"]);
+});
+
+test("test computed node label undefined is valid (omitted)", async () => {
+  const { validateGraphData } = await import("../../src/validator");
+  const graph_data = {
+    version: graphDataLatestVersion,
+    nodes: {
+      computed1: { agent: "echoAgent" },
     },
   };
   validateGraphData(graph_data, ["echoAgent"]);

--- a/packages/graphai/tests/validators/test_validator_computed_node.ts
+++ b/packages/graphai/tests/validators/test_validator_computed_node.ts
@@ -28,3 +28,30 @@ test("test static node validation value", async () => {
   });
   await rejectTest(__dirname, graph_data, "Computed node does not allow update");
 });
+
+test("test computed node label must be a string", async () => {
+  const graph_data = anonymization({
+    version: graphDataLatestVersion,
+    nodes: {
+      computed1: {
+        agent: "echoAgent",
+        label: 5,
+      },
+    },
+  });
+  await rejectTest(__dirname, graph_data, "Computed node label must be a string");
+});
+
+test("test computed node label string is valid", async () => {
+  const { validateGraphData } = await import("../../src/validator");
+  const graph_data = {
+    version: graphDataLatestVersion,
+    nodes: {
+      computed1: {
+        agent: "echoAgent",
+        label: "openai",
+      },
+    },
+  };
+  validateGraphData(graph_data, ["echoAgent"]);
+});

--- a/packages/graphai/tests/validators/test_validator_graph_data.ts
+++ b/packages/graphai/tests/validators/test_validator_graph_data.ts
@@ -1,8 +1,10 @@
 import { anonymization, rejectTest } from "@receptron/test_utils";
 import { graphDataLatestVersion } from "../common";
 import { validateGraphData } from "../../src/validator";
+import type { ConcurrencyConfig } from "../../src/type";
 
 import test from "node:test";
+import assert from "node:assert";
 
 const nodes = {
   echo: {
@@ -291,6 +293,62 @@ test("test concurrency.labels.<key> empty key still validated", async () => {
     nodes,
   });
   await rejectTest(__dirname, graphdata, "Concurrency.labels. must be a positive integer");
+});
+
+// Reject extra keys on the concurrency object so typos do not silently
+// disable enforcement.
+test("test concurrency object form extra key rejected", async () => {
+  const graphdata = anonymization({
+    version: graphDataLatestVersion,
+    concurrency: { global: 5, foo: 1 },
+    nodes,
+  });
+  await rejectTest(__dirname, graphdata, "Concurrency object does not allow foo");
+});
+
+// Reject non-plain-object shapes that would otherwise pass typeof "object"
+// and yield no entries via Object.entries -- silently disabling enforcement.
+// These tests intentionally bypass anonymization (which JSON-roundtrips and
+// would convert Map/Date/class instances to plain objects/strings, hiding
+// what the validator actually sees in code that constructs graph data
+// programmatically).
+test("test concurrency Map rejected", () => {
+  const graphdata = {
+    version: graphDataLatestVersion,
+    concurrency: new Map([["global", 5]]) as unknown as ConcurrencyConfig,
+    nodes,
+  };
+  assert.throws(() => validateGraphData(graphdata, ["echoAgent"]), /Concurrency must be an integer/);
+});
+
+test("test concurrency Date rejected", () => {
+  const graphdata = {
+    version: graphDataLatestVersion,
+    concurrency: new Date() as unknown as ConcurrencyConfig,
+    nodes,
+  };
+  assert.throws(() => validateGraphData(graphdata, ["echoAgent"]), /Concurrency must be an integer/);
+});
+
+test("test concurrency.labels Map rejected", () => {
+  const graphdata = {
+    version: graphDataLatestVersion,
+    concurrency: { global: 5, labels: new Map([["openai", 3]]) as unknown as Record<string, number> },
+    nodes,
+  };
+  assert.throws(() => validateGraphData(graphdata, ["echoAgent"]), /Concurrency\.labels must be an object/);
+});
+
+test("test concurrency.labels class instance rejected", () => {
+  class Limits {
+    openai = 3;
+  }
+  const graphdata = {
+    version: graphDataLatestVersion,
+    concurrency: { global: 5, labels: new Limits() as unknown as Record<string, number> },
+    nodes,
+  };
+  assert.throws(() => validateGraphData(graphdata, ["echoAgent"]), /Concurrency\.labels must be an object/);
 });
 
 // metadata test

--- a/packages/graphai/tests/validators/test_validator_graph_data.ts
+++ b/packages/graphai/tests/validators/test_validator_graph_data.ts
@@ -73,6 +73,96 @@ test("test concurrency error string", async () => {
   await rejectTest(__dirname, graphdata, "Concurrency must be an integer");
 });
 
+test("test concurrency valid number", async () => {
+  const graphdata = {
+    version: graphDataLatestVersion,
+    concurrency: 5,
+    nodes,
+  };
+  validateGraphData(graphdata, ["echoAgent"]);
+});
+
+test("test concurrency valid number one", async () => {
+  const graphdata = {
+    version: graphDataLatestVersion,
+    concurrency: 1,
+    nodes,
+  };
+  validateGraphData(graphdata, ["echoAgent"]);
+});
+
+test("test concurrency undefined is allowed", async () => {
+  const graphdata = {
+    version: graphDataLatestVersion,
+    nodes,
+  };
+  validateGraphData(graphdata, ["echoAgent"]);
+});
+
+// ConcurrencyConfig (object form) tests
+test("test concurrency object form valid", async () => {
+  const graphdata = {
+    version: graphDataLatestVersion,
+    concurrency: { global: 5, labels: { openai: 2, vertex: 3 } },
+    nodes,
+  };
+  validateGraphData(graphdata, ["echoAgent"]);
+});
+
+test("test concurrency object form without labels", async () => {
+  const graphdata = {
+    version: graphDataLatestVersion,
+    concurrency: { global: 5 },
+    nodes,
+  };
+  validateGraphData(graphdata, ["echoAgent"]);
+});
+
+test("test concurrency object form missing global", async () => {
+  const graphdata = anonymization({
+    version: graphDataLatestVersion,
+    concurrency: { labels: { openai: 2 } },
+    nodes,
+  });
+  await rejectTest(__dirname, graphdata, "Concurrency object must have a global field");
+});
+
+test("test concurrency object form invalid global", async () => {
+  const graphdata = anonymization({
+    version: graphDataLatestVersion,
+    concurrency: { global: 0 },
+    nodes,
+  });
+  await rejectTest(__dirname, graphdata, "Concurrency.global must be a positive integer");
+});
+
+test("test concurrency object form invalid label value", async () => {
+  const graphdata = anonymization({
+    version: graphDataLatestVersion,
+    concurrency: { global: 5, labels: { openai: 0 } },
+    nodes,
+  });
+  await rejectTest(__dirname, graphdata, "Concurrency.labels.openai must be a positive integer");
+});
+
+test("test concurrency object form non-integer label value", async () => {
+  const graphdata = anonymization({
+    version: graphDataLatestVersion,
+    concurrency: { global: 5, labels: { openai: 1.5 } },
+    nodes,
+  });
+  await rejectTest(__dirname, graphdata, "Concurrency.labels.openai must be an integer");
+});
+
+test("test concurrency labels not an object", async () => {
+  const graphdata = anonymization({
+    version: graphDataLatestVersion,
+    concurrency: { global: 5, labels: [] },
+    nodes,
+  });
+  await rejectTest(__dirname, graphdata, "Concurrency.labels must be an object");
+});
+
 // metadata test
 test("test metadata", async () => {
   const graphdata = {

--- a/packages/graphai/tests/validators/test_validator_graph_data.ts
+++ b/packages/graphai/tests/validators/test_validator_graph_data.ts
@@ -163,6 +163,136 @@ test("test concurrency labels not an object", async () => {
   await rejectTest(__dirname, graphdata, "Concurrency.labels must be an object");
 });
 
+test("test concurrency labels null is rejected", async () => {
+  const graphdata = anonymization({
+    version: graphDataLatestVersion,
+    concurrency: { global: 5, labels: null },
+    nodes,
+  });
+  await rejectTest(__dirname, graphdata, "Concurrency.labels must be an object");
+});
+
+// Top-level concurrency malformed shapes
+test("test concurrency null rejected", async () => {
+  const graphdata = anonymization({
+    version: graphDataLatestVersion,
+    concurrency: null,
+    nodes,
+  });
+  await rejectTest(__dirname, graphdata, "Concurrency must be an integer");
+});
+
+test("test concurrency boolean rejected", async () => {
+  const graphdata = anonymization({
+    version: graphDataLatestVersion,
+    concurrency: true,
+    nodes,
+  });
+  await rejectTest(__dirname, graphdata, "Concurrency must be an integer");
+});
+
+test("test concurrency array rejected", async () => {
+  const graphdata = anonymization({
+    version: graphDataLatestVersion,
+    concurrency: [],
+    nodes,
+  });
+  await rejectTest(__dirname, graphdata, "Concurrency must be an integer");
+});
+
+// Concurrency.global malformed shapes
+test("test concurrency.global string rejected", async () => {
+  const graphdata = anonymization({
+    version: graphDataLatestVersion,
+    concurrency: { global: "5" },
+    nodes,
+  });
+  await rejectTest(__dirname, graphdata, "Concurrency.global must be an integer");
+});
+
+test("test concurrency.global null rejected", async () => {
+  const graphdata = anonymization({
+    version: graphDataLatestVersion,
+    concurrency: { global: null },
+    nodes,
+  });
+  await rejectTest(__dirname, graphdata, "Concurrency.global must be an integer");
+});
+
+test("test concurrency.global negative rejected", async () => {
+  const graphdata = anonymization({
+    version: graphDataLatestVersion,
+    concurrency: { global: -1 },
+    nodes,
+  });
+  await rejectTest(__dirname, graphdata, "Concurrency.global must be a positive integer");
+});
+
+test("test concurrency.global float rejected", async () => {
+  const graphdata = anonymization({
+    version: graphDataLatestVersion,
+    concurrency: { global: 1.5 },
+    nodes,
+  });
+  await rejectTest(__dirname, graphdata, "Concurrency.global must be an integer");
+});
+
+// Concurrency.labels.<key> malformed values
+test("test concurrency.labels.<key> string rejected", async () => {
+  const graphdata = anonymization({
+    version: graphDataLatestVersion,
+    concurrency: { global: 5, labels: { openai: "3" } },
+    nodes,
+  });
+  await rejectTest(__dirname, graphdata, "Concurrency.labels.openai must be an integer");
+});
+
+test("test concurrency.labels.<key> null rejected", async () => {
+  const graphdata = anonymization({
+    version: graphDataLatestVersion,
+    concurrency: { global: 5, labels: { openai: null } },
+    nodes,
+  });
+  await rejectTest(__dirname, graphdata, "Concurrency.labels.openai must be an integer");
+});
+
+test("test concurrency.labels.<key> negative rejected", async () => {
+  const graphdata = anonymization({
+    version: graphDataLatestVersion,
+    concurrency: { global: 5, labels: { openai: -2 } },
+    nodes,
+  });
+  await rejectTest(__dirname, graphdata, "Concurrency.labels.openai must be a positive integer");
+});
+
+test("test concurrency.labels.<key> boolean rejected", async () => {
+  const graphdata = anonymization({
+    version: graphDataLatestVersion,
+    concurrency: { global: 5, labels: { openai: true } },
+    nodes,
+  });
+  await rejectTest(__dirname, graphdata, "Concurrency.labels.openai must be an integer");
+});
+
+test("test concurrency.labels.<key> object rejected", async () => {
+  const graphdata = anonymization({
+    version: graphDataLatestVersion,
+    concurrency: { global: 5, labels: { openai: { value: 3 } } },
+    nodes,
+  });
+  await rejectTest(__dirname, graphdata, "Concurrency.labels.openai must be an integer");
+});
+
+test("test concurrency.labels.<key> empty key still validated", async () => {
+  // An empty-string key is unusual but the validator should still walk it.
+  const graphdata = anonymization({
+    version: graphDataLatestVersion,
+    concurrency: { global: 5, labels: { "": 0 } },
+    nodes,
+  });
+  await rejectTest(__dirname, graphdata, "Concurrency.labels. must be a positive integer");
+});
+
 // metadata test
 test("test metadata", async () => {
   const graphdata = {

--- a/plans/feat-concurrency-per-label.md
+++ b/plans/feat-concurrency-per-label.md
@@ -1,0 +1,116 @@
+# feat: concurrency per label (#1304)
+
+## User Prompt
+
+> 現在の GraphAI では `concurrency` は全体の同時実行数だけだが、特定 LLM/外部 API ごとに並列上限を設定したい（レート制限対策）。
+>
+> agent 単位 / agent + model 単位 / または node に label を付けて label 単位、で制御したい。
+>
+> 例:
+> ```yaml
+> concurrency:
+>   global: 20
+>   labels:
+>     openai: 3
+>     vertex: 5
+> ```
+>
+> aging / weight / RPM(token bucket) はそれぞれ別チケット (#1311, #1312, #1313) に切り出した。
+>
+> このチケットでは **concurrency per label のみ** を実装。HoL (head-of-line) skip 方式 = キュー先頭から走査して global 枠 AND label 枠の空いている最初のタスクを dequeue する。priority は既存実装のまま使う。
+
+## Goal
+
+`TaskManager` を拡張し、グラフ全体の concurrency 上限に加えて label ごとの上限も同時に守れるようにする。後方互換は完全に維持（既存の `concurrency: number` 形式とラベルなしノードはそのまま動く）。
+
+## Schema
+
+### GraphData.concurrency 拡張
+
+```typescript
+type ConcurrencyConfig =
+  | number                                          // 旧形式（global のみ）
+  | { global: number; labels?: Record<string, number> };
+
+type GraphData = {
+  // ...
+  concurrency?: ConcurrencyConfig;
+};
+```
+
+### ComputedNodeData
+
+```typescript
+type ComputedNodeData = {
+  // ... 既存フィールド
+  label?: string; // optional. 未指定なら label 制限の対象外
+};
+```
+
+## TaskManager の変更点
+
+### 内部状態
+
+```typescript
+private globalLimit: number;
+private labelLimits: Map<string, number>;        // label -> max
+private runningByLabel: Map<string, number>;     // label -> current running count
+// runningNodes: Set<ComputedNode> は維持（global の running 数把握用）
+```
+
+### dequeueTaskIfPossible（HoL skip）
+
+1. global 枠 (`runningNodes.size < globalLimit`) を確認
+2. キューを先頭（最高 priority）から走査
+3. 各タスクの label について `labelLimits` を確認
+   - label 未指定 or label が `labelLimits` にない → global 枠だけで判断
+   - label に上限あり → `runningByLabel.get(label) < labelLimits.get(label)` も満たす必要
+4. 最初に条件を満たしたタスクを `splice` で取り出し実行
+5. 該当なしなら何もしない（次の onComplete を待つ）
+
+### addTask / onComplete
+
+- `addTask`: 既存の priority 降順 splice はそのまま
+- 実行開始時に `runningByLabel` をインクリメント
+- `onComplete` で `runningByLabel` をデクリメント
+
+### prepareForNesting / restoreAfterNesting
+
+- 現状は `concurrency++` していた → `globalLimit++` に変更
+- label 側はいじらない（nested graph の deadlock 回避は global 枠だけで足りる）
+
+## Validators
+
+- `validators/graph_data_validator.ts`: `concurrency` が number または `{ global: number, labels?: Record<string, number> }` のいずれかであることを検証
+- 各値は正の整数
+
+## ファイル変更
+
+| ファイル | 変更内容 |
+|---|---|
+| `packages/graphai/src/type.ts` | `ComputedNodeData.label` 追加、`GraphData.concurrency` を union 型に |
+| `packages/graphai/src/task_manager.ts` | 上記の通り拡張 |
+| `packages/graphai/src/graphai.ts` | TaskManager コンストラクタへ新形式を渡す箇所の修正 |
+| `packages/graphai/src/node.ts` | `ComputedNode` から label を読み出して TaskManager に渡す |
+| `packages/graphai/src/validators/graph_data_validator.ts` | concurrency の検証拡張 |
+| `packages/graphai/tests/units/test_task_manager.ts` | 新規。HoL skip / label limit / 後方互換のユニットテスト |
+| `packages/graphai/tests/validators/test_validator_graph_data.ts` | concurrency バリデーションのテスト追加 |
+
+## 後方互換
+
+- `concurrency: number` のまま動く（内部で `{ global: N, labels: {} }` に正規化）
+- label を持たないノードは現状とまったく同じ動作
+- `prepareForNesting()` の挙動は不変
+
+## Validation
+
+- `yarn format`
+- `yarn eslint`（既存の untracked ファイルのエラーは除く）
+- `yarn build`
+- `yarn test`（特に `packages/graphai`）
+
+## Out of scope (followups)
+
+- #1311: aging（HoL skip のスターベーション保険）
+- #1312: weight（タスク重みベースの concurrency）
+- #1313: RPM/TPM レート制限（token bucket）

--- a/plans/feat-concurrency-per-label.md
+++ b/plans/feat-concurrency-per-label.md
@@ -52,7 +52,7 @@ type ComputedNodeData = {
 ### 内部状態
 
 ```typescript
-private globalLimit: number;
+private concurrency: number;                     // global limit (existing field, repurposed)
 private labelLimits: Map<string, number>;        // label -> max
 private runningByLabel: Map<string, number>;     // label -> current running count
 // runningNodes: Set<ComputedNode> は維持（global の running 数把握用）
@@ -60,7 +60,7 @@ private runningByLabel: Map<string, number>;     // label -> current running cou
 
 ### dequeueTaskIfPossible（HoL skip）
 
-1. global 枠 (`runningNodes.size < globalLimit`) を確認
+1. global 枠 (`runningNodes.size < concurrency`) を確認
 2. キューを先頭（最高 priority）から走査
 3. 各タスクの label について `labelLimits` を確認
    - label 未指定 or label が `labelLimits` にない → global 枠だけで判断
@@ -76,8 +76,8 @@ private runningByLabel: Map<string, number>;     // label -> current running cou
 
 ### prepareForNesting / restoreAfterNesting
 
-- 現状は `concurrency++` していた → `globalLimit++` に変更
-- label 側はいじらない（nested graph の deadlock 回避は global 枠だけで足りる）
+- `concurrency++` はそのまま（global 枠のみ）
+- label 側はいじらない（nested graph の deadlock 回避は per-parent-graphId bypass で対応）
 
 ## Validators
 


### PR DESCRIPTION
Closes #1304

## Summary

- `GraphData.concurrency` is extended to accept either a number (legacy) or `{ global: number, labels?: Record<string, number> }`.
- `ComputedNodeData` gains an optional `label: string`. When set on a node and the label has a configured limit, that node counts against the per-label cap as well as the global cap.
- `TaskManager` walks the priority-sorted queue and dispatches the first task whose label still has capacity ("head-of-line skip"), so a saturated label cannot stall unrelated work.
- 100% backward compatible: `concurrency: number` and unlabeled nodes behave exactly as before.

## Items to Confirm / Review

1. **HoL skip vs strict priority order** — when the highest-priority queued task is blocked by its label, lower-priority tasks of *other* labels are dispatched first. This is documented in the issue and intended (otherwise label limits would degenerate into global stalls), but it does mean priority is now "priority within a feasible-label set." Starvation of a hot label is possible by design; aging is split out to #1311.
2. **`onComplete` drains aggressively** — when a label slot opens, `onComplete` keeps dispatching while the global limit allows. This is what makes mixed labeled/free-label workloads behave like the user expects, but please sanity-check the loop condition in `task_manager.ts:108-114`.
3. **Nested graphs** — `prepareForNesting()`/`restoreAfterNesting()` still touch only the global limit. Per-label limits are not bumped when nested graphs run. If a nested graph's tasks share a label with the parent, they share the cap. Flag if a different policy is wanted.
4. **Validator messages** — the new error messages (`Concurrency.global must be ...`, `Concurrency.labels.<key> must be ...`) follow the existing `Concurrency must be ...` style. Check the tone matches your preference.

## User Prompt

> 現在のGraphAIでは concurrency は全体の同時実行数だけだが、特定LLM/外部APIごとに並列上限を設定したい（レート制限対策）。agent単位 / agent + model単位 / または node に label を付けて label単位、で制御したい。
>
> 例:
> ```yaml
> concurrency:
>   global: 20
>   labels:
>     openai: 3
>     vertex: 5
> ```
>
> 設計判断:
> - HoL skip 方式 (B案) — キュー先頭から走査して、global枠 AND label枠が空いている最初のタスクを dispatch
> - priority は既存の数値仕様をそのまま維持（数値が大きいほど優先）
>
> aging / weight / RPM(token bucket) はそれぞれ別チケットに切り出した:
> - #1311 aging
> - #1312 weight
> - #1313 token bucket / RPM・TPM
>
> 事前に変更箇所のユニットテストが足りているかチェックし、不足していれば現状動作を locked-in するテストを足してから実装すること。

## Implementation Approach

### Order of work (TDD-ish)

1. **Coverage gap audit** — `TaskManager` had **zero** direct unit tests. Validator only had 4 negative tests for `concurrency`.
2. **Characterization tests first** — added 9 tests locking current TaskManager behavior (priority order, FIFO, prepareForNesting, isRunning, reset, getStatus, etc.) and 3 positive tests for the validator. Confirmed all 212 baseline tests pass on unchanged code.
3. **Implement** — type.ts, task_manager.ts, node.ts, validator.
4. **Add label-feature tests** — 10 new TaskManager tests + 7 new validator tests covering object-form concurrency.
5. **Verify** — `yarn build`, `yarn test` (all 19 workspaces, fail 0), `yarn format`.

### Files changed

| File | Change |
|---|---|
| `packages/graphai/src/type.ts` | Add `ComputedNodeData.label`, `ConcurrencyConfig`, union `concurrency` |
| `packages/graphai/src/task_manager.ts` | Constructor accepts union; HoL skip; per-label running counts |
| `packages/graphai/src/node.ts` | Read `data.label` into `ComputedNode.label` |
| `packages/graphai/src/validators/common.ts` | `label` added to allowed computed-node attribute keys |
| `packages/graphai/src/validators/graph_data_validator.ts` | Validate object-form concurrency |
| `packages/graphai/tests/units/test_task_manager.ts` | **New** — 19 tests |
| `packages/graphai/tests/validators/test_validator_graph_data.ts` | +10 tests |
| `plans/feat-concurrency-per-label.md` | **New** — design doc |

### Algorithm sketch (TaskManager.dequeueTaskIfPossible)

```
if global_running >= global_limit: return
for task in queue (priority desc):
    label = task.node.label
    if label is None or label not in labelLimits:
        dispatch(task); return
    if running_by_label[label] < labelLimits[label]:
        dispatch(task); return
return  # nothing eligible right now; wait for next onComplete
```

`onComplete` then loops `dequeueTaskIfPossible` while progress is being made, so a single completion can dispatch multiple newly-eligible queued tasks (bounded by the global limit).

## Validation

- [x] `yarn build` — succeeds across all workspaces
- [x] `yarn test` — 19 workspaces, 0 failures (graphai package: 212 → 229 tests after this PR)
- [x] `yarn format` — clean
- [x] `yarn pack --dry-run` not applicable (no package.json change)
- [ ] `yarn eslint` — preexisting errors only in untracked scratch files (`tests/ensemble.ts`, `tests/runner.ts`, `tests/units/test_aaa.ts`, `tests/units/test_graph_aaa.ts`); no errors introduced by this PR

## Test plan

- [ ] CI passes
- [ ] Manual: write a graph with `concurrency: { global: 10, labels: { openai: 2 } }`, send 6 nodes labeled `openai` and confirm only 2 run concurrently while other labels run freely
- [ ] Manual: confirm legacy `concurrency: 5` graphs continue to work without changes

## Out of scope (followups)

- #1311 — aging / starvation prevention
- #1312 — weighted concurrency (heavy LLM calls consume multiple slots)
- #1313 — RPM/TPM rate limiting (token bucket)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional node labels for grouping tasks and applying per-label concurrency limits.
  * Scheduler now respects per-label limits and skips blocked queue heads so eligible tasks can run.

* **Bug Fixes**
  * Nesting/preparation now correctly preserves and restores label-aware concurrency state across early exits.

* **Tests**
  * Expanded tests covering label validation, label-aware scheduling, nesting, and concurrency behaviors.

* **Documentation**
  * Added design doc describing label-based concurrency controls.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->