### PR TITLE
fix: build apiDocMd / agentDocs README so breadcrumbs resolve (#1324)

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -43,7 +43,12 @@ export default defineConfig({
     "./inputs.md",
     "./Tutorial.md",
     // non document
-    "**/README.md",
+    // NOTE: do not exclude README.md globally -- the typedoc-generated pages
+    // under apiDocMd/ and agentDocs/ link back to their respective README.md
+    // as the breadcrumb. Exclude only the dev-only READMEs so the auto-doc
+    // breadcrumbs resolve on the live site.
+    "./README.md",
+    "./examples/tutorial/README.md",
     "./Tutorial.template.md",
     "./document_generation.md",
   ],

--- a/plans/fix-docs-readme-404.md
+++ b/plans/fix-docs-readme-404.md
@@ -1,0 +1,49 @@
+# fix: docs README.html 404 in apiDocMd / agentDocs (#1324)
+
+## User Prompt
+
+> 公式ドキュメントを読んでいる時に気づきましたが、ReadMeが404になっているようです：
+> - https://graphai.info/docs/apiDocMd/README.html
+> - https://graphai.info/docs/agentDocs/README.html
+
+(後続コメントで実際の URL は `/docs/` プレフィックスなし、`https://graphai.info/apiDocMd/README.html` 等であることを確認)
+
+## Root cause
+
+`docs/.vitepress/config.mts:46` の `srcExclude` で `"**/README.md"` を指定しているため、すべての `README.md` が VitePress のビルドから除外されている。
+
+しかし、typedoc が生成した `apiDocMd/` 配下の各 `.md` は先頭にパンくずリンクとして `[**graphai**](README.md)` (または `(../README.md)`) を含んでおり、ライブサイトでクリックすると 404 になる。
+
+## Fix
+
+`"**/README.md"` を、開発者向けで非公開にしておきたい 2 つの README に限定する：
+
+```diff
+ srcExclude: [
+   ...,
+-  "**/README.md",
++  "./README.md",
++  "./examples/tutorial/README.md",
+   ...
+ ],
+```
+
+これにより、以下のような状態になる：
+
+| ファイル | 公開可否 | ビルド後 URL |
+|---|---|---|
+| `docs/README.md` | 非公開（開発者向け） | (excluded) |
+| `docs/examples/tutorial/README.md` | 非公開 | (excluded) |
+| `docs/apiDocMd/README.md` | **公開** | `/apiDocMd/README.html` |
+| `docs/agentDocs/README.md` | **公開** | `/agentDocs/README.html` |
+
+## Validation
+
+- `cd docs && yarn install` (もし未インストール)
+- `cd docs && yarn build` (または vitepress build) → `.vitepress/dist/apiDocMd/README.html` と `.vitepress/dist/agentDocs/README.html` の存在を確認
+- 念のため `.vitepress/dist/README.html` が **存在しない** ことも確認（dev-only README の除外が効いている）
+
+## Out of scope
+
+- パンくずリンクの destination を `globals.html` に書き換える方向の修正（typedoc 出力に手を入れる必要があり、生成のたびに巻き戻る）
+- VitePress nav に README ページを追加する話（既存ナビ構造を維持）


### PR DESCRIPTION
Closes #1324

## Summary

Two pages on the live docs site return 404 because VitePress excluded every \`README.md\` from the build, but the typedoc-generated pages link back to them in their breadcrumb:

- https://graphai.info/apiDocMd/README.html -> **404**
- https://graphai.info/agentDocs/README.html -> **404**

(Compare with sibling pages that work: \`/apiDocMd/globals.html\`, \`/agentDocs/llm/groqAgent.html\`.)

## Items to Confirm / Review

1. **Scope of the README change**: replacing the wildcard with two explicit excludes keeps \`docs/README.md\` and \`docs/examples/tutorial/README.md\` out of the public site while exposing only the two auto-generated index READMEs. Flag if either of the kept-private READMEs should also be public, or vice versa.
2. **No content edits**: the fix is purely in \`docs/.vitepress/config.mts\`. The README.md files themselves are unchanged; they were already in the repo, just unbuildable.
3. **Verified locally with \`yarn build\`** under \`docs/\` — the two target pages now generate; the dev-only ones still don't.

## User Prompt

> 公式ドキュメントを読んでいる時に気づきましたが、ReadMeが404になっているようです：
> - https://graphai.info/apiDocMd/README.html
> - https://graphai.info/agentDocs/README.html
>
> docs以下のことです。

## Root cause

\`docs/.vitepress/config.mts\` had:

\`\`\`ts
srcExclude: [
  ...,
  "**/README.md",   // ← excludes every README.md in the entire tree
  ...
],
\`\`\`

But typedoc breadcrumbs at the top of every generated page point back to README.md:

\`\`\`md
# docs/apiDocMd/classes/GraphAI.md
[**graphai**](../README.md)
\`\`\`

\`\`\`md
# docs/apiDocMd/globals.md
[**graphai**](README.md)
\`\`\`

Clicking those breadcrumbs lands on a path that VitePress refused to build, hence the 404s.

## Fix

Replace the wildcard with explicit per-file excludes:

\`\`\`diff
 srcExclude: [
   ...,
-  "**/README.md",
+  // NOTE: do not exclude README.md globally -- the typedoc-generated pages
+  // under apiDocMd/ and agentDocs/ link back to their respective README.md
+  // as the breadcrumb. Exclude only the dev-only READMEs so the auto-doc
+  // breadcrumbs resolve on the live site.
+  "./README.md",
+  "./examples/tutorial/README.md",
   ...
 ],
\`\`\`

Result after \`yarn build\` under \`docs/\`:

| File | Built? | Intent |
|---|---|---|
| \`.vitepress/dist/apiDocMd/README.html\` | ✅ yes | linked from typedoc breadcrumbs |
| \`.vitepress/dist/agentDocs/README.html\` | ✅ yes | agent index, also linked from \`document_generation.md\` |
| \`.vitepress/dist/README.html\` | ❌ no | dev-only, kept out of site |
| \`.vitepress/dist/examples/tutorial/README.html\` | ❌ no | tutorial source, kept out of site |

## Test plan

- [ ] CI passes
- [ ] After merge + Firebase deploy, manually verify:
  - https://graphai.info/apiDocMd/README.html returns 200
  - https://graphai.info/agentDocs/README.html returns 200
  - https://graphai.info/ (root) is unchanged
  - https://graphai.info/examples/tutorial/README.html stays 404 (dev-only, intended)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved 404 errors preventing access to API documentation and agent documentation pages.

* **Documentation**
  * Added documentation outlining the fix applied.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->