### PR TITLE
fix(graphai): preserve nesting headroom (regression from #1314 — nested mapAgent fails with "Concurrency is too low")

### DIFF
--- a/packages/graphai/src/task_manager.ts
+++ b/packages/graphai/src/task_manager.ts
@@ -181,14 +181,15 @@ export class TaskManager {
       }
       perParent.set(parentGraphId, (perParent.get(parentGraphId) ?? 0) + 1);
     }
-    // Both the global slot bump and the optional label bypass can free capacity
-    // for already-queued tasks; drain the queue while progress is being made.
-    let progressed = true;
-    while (progressed) {
-      const before = this.runningNodes.size;
-      this.dequeueTaskIfPossible();
-      progressed = this.runningNodes.size > before;
-    }
+    // IMPORTANT: do NOT drain the queue here. The concurrency++ above reserves a
+    // slot so the nested graph's own children have headroom to run (deadlock
+    // avoidance, which mapAgent asserts via `concurrency > running`). At this
+    // point the nested children are not queued yet -- the nested graph is built
+    // and run *after* prepareForNesting returns -- so draining now can only
+    // dispatch unrelated already-queued sibling tasks into the reserved slot,
+    // immediately consuming the headroom and tripping mapAgent's guard. The
+    // nested children, and any newly-eligible queued tasks, are dispatched when
+    // they call addTask() or when a slot frees up in onComplete().
   }
 
   public restoreAfterNesting(label?: string, parentGraphId?: string) {

--- a/packages/graphai/tests/units/test_nested_concurrency.ts
+++ b/packages/graphai/tests/units/test_nested_concurrency.ts
@@ -1,0 +1,61 @@
+import { GraphAI } from "../../src/index";
+import * as agents from "../test_agents";
+import { graphDataLatestVersion } from "../common";
+
+import test from "node:test";
+import assert from "node:assert";
+
+// Regression for the "mapAgent: Concurrency is too low" failure caused by
+// prepareForNesting draining its reserved slot into queued siblings.
+//
+// Structure mirrors a real-world graph (e.g. mulmocast translate): a mapAgent
+// whose nested graph itself contains another mapAgent. With concurrency: 1 and
+// multiple rows, sibling map children are queued at the moment an inner mapAgent
+// prepares for nesting. The buggy drain loop handed the reserved headroom to a
+// sibling, so the inner mapAgent saw running == concurrency and threw.
+test("nested mapAgent within mapAgent does not trip the concurrency guard", async () => {
+  const innermost = {
+    version: graphDataLatestVersion,
+    nodes: {
+      row: {},
+      out: { isResult: true, agent: "copyAgent", params: { namedKey: "row" }, inputs: { row: ":row" } },
+    },
+  };
+
+  const innerGraph = {
+    version: graphDataLatestVersion,
+    nodes: {
+      row: {},
+      inner: {
+        agent: "mapAgent",
+        inputs: { rows: ":row" },
+        params: { compositeResult: true },
+        graph: innermost,
+      },
+      result: { isResult: true, agent: "copyAgent", params: { namedKey: "out" }, inputs: { out: ":inner.out" } },
+    },
+  };
+
+  const graph_data = {
+    version: graphDataLatestVersion,
+    concurrency: 1,
+    nodes: {
+      data: { value: [[1, 2], [3, 4], [5, 6]] },
+      outerMap: {
+        agent: "mapAgent",
+        inputs: { rows: ":data" },
+        params: { compositeResult: true },
+        graph: innerGraph,
+      },
+      result: { isResult: true, agent: "copyAgent", params: { namedKey: "result" }, inputs: { result: ":outerMap.result" } },
+    },
+  };
+
+  const graphai = new GraphAI(graph_data, agents);
+  const result = await graphai.run<{ result: unknown[] }>();
+  assert.deepStrictEqual(result.result, [
+    [1, 2],
+    [3, 4],
+    [5, 6],
+  ]);
+});

--- a/packages/graphai/tests/units/test_task_manager.ts
+++ b/packages/graphai/tests/units/test_task_manager.ts
@@ -163,6 +163,36 @@ test("TaskManager prepareForNesting / restoreAfterNesting bumps capacity", () =>
   assert.equal(tm.getStatus().concurrency, 1);
 });
 
+// Regression: prepareForNesting must NOT drain its newly-reserved slot into an
+// already-queued sibling. The concurrency++ reserves headroom for the nested
+// graph's own children (deadlock avoidance, asserted by mapAgent via
+// `concurrency > running`). A prior version drained the queue here, so a queued
+// sibling stole the reserved slot, running caught up to concurrency, and nested
+// mapAgents tripped "mapAgent: Concurrency is too low".
+test("TaskManager prepareForNesting preserves reserved headroom (does not dispatch queued siblings)", () => {
+  const tm = new TaskManager(1);
+  const { executed, callback } = collectExecutionOrder();
+
+  // "a" runs and fills the only slot; "sibling" is queued.
+  tm.addTask(makeNode("a"), "g1", callback);
+  tm.addTask(makeNode("sibling"), "g1", callback);
+  assert.deepStrictEqual(executed, ["a"]);
+  assert.equal(tm.getStatus().queue, 1);
+
+  // "a" is about to invoke a nested graph. The bumped slot must stay reserved as
+  // headroom -- it must NOT be drained into the queued sibling. This is the exact
+  // invariant the buggy drain loop violated (it bumped running to 2 == concurrency,
+  // leaving no headroom and tripping mapAgent's `concurrency > running` guard).
+  tm.prepareForNesting();
+  assert.equal(tm.getStatus().concurrency, 2);
+  assert.deepStrictEqual(executed, ["a"]); // sibling must NOT have been dispatched
+  assert.equal(tm.getStatus().running, 1); // headroom preserved: running(1) < concurrency(2)
+  assert.equal(tm.getStatus().queue, 1);
+
+  tm.restoreAfterNesting();
+  assert.equal(tm.getStatus().concurrency, 1);
+});
+
 test("TaskManager getStatus reports verbose node ids when requested", () => {
   const tm = new TaskManager(1);
   const { callback } = collectExecutionOrder();


### PR DESCRIPTION
## Summary

Fixes a regression introduced by #1314 (`feat: concurrency per label with head-of-line skip`). A graph with a **mapAgent whose nested graph contains another mapAgent** (e.g. mulmocast's `translate` action) now fails with:

```
mapAgent: Concurrency is too low: <n>
```

…even when **per-label concurrency is not used at all**. It affects the plain `concurrency: number` path.

## Root cause

`prepareForNesting()` bumps `concurrency` to reserve a slot so the nested graph's own children have headroom to run — this is the deadlock-avoidance invariant that `mapAgent` asserts via `concurrency > running`.

#1314 added a drain loop at the end of `prepareForNesting()`:

```ts
this.concurrency++;
...
let progressed = true;
while (progressed) {
  const before = this.runningNodes.size;
  this.dequeueTaskIfPossible();
  progressed = this.runningNodes.size > before;
}
```

When a sibling task is already queued (common under a low global limit), this drain immediately dispatches it into the just-reserved slot, pushing `running` up to `concurrency`. The next nested `mapAgent` then sees `running == concurrency` (no headroom) and throws.

At `prepareForNesting` time the nested children are **not queued yet** — the nested graph is built and run *after* `prepareForNesting` returns — so the drain can only consume the reservation with unrelated sibling work.

## Fix

Remove the drain loop from `prepareForNesting()`. Nested children and any newly-eligible queued tasks are dispatched when they call `addTask()` or when a slot frees up in `onComplete()` (the `onComplete` drain loop is **kept**). This restores the pre-#1314 behavior on the global path while leaving the per-label feature intact.

## Tests

- **unit** (`test_task_manager.ts`): `prepareForNesting` must not dispatch a queued sibling — headroom preserved (`running < concurrency` after the bump). The pre-existing nesting test had no queued sibling, which is why the regression slipped through.
- **integration** (`test_nested_concurrency.ts`, new): a mapAgent whose nested graph contains another mapAgent runs to completion under `concurrency: 1`. Verified to **fail** (`Concurrency is too low: 5`) on the unfixed code and **pass** with the fix.

`npx tsc --noEmit` clean. The 8 pre-existing `Cannot find module './array_find_first_exists'` failures in the suite are unrelated (present on a clean checkout of `main`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved concurrency handling for nested graph execution to prevent task queue overflow and ensure correct task ordering in scenarios with concurrency constraints. This resolves an issue where nested operations could trigger spurious concurrency-related guard conditions, enhancing the reliability of concurrent nested graph processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->