### PR TITLE
ci: harden Update Build workflow against concurrent push race

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,18 +32,22 @@ jobs:
         git config user.name "GitHub Actions Bot"
         git config user.email "<>"
         git add packages/*/lib/* docs/agentDocs/* docs/apiDoc/* llm_agents/*/README.md agents/*/README.md packages/*/README.md
-    - name: Commit 
+    - name: Commit
       run: |
         if [ $(git diff --name-only --cached | wc -l) != 0 ]; then
           git commit -m "Update lib or docs" packages/*/lib/ docs/agentDocs/* docs/apiDoc/* llm_agents/*/README.md agents/*/README.md packages/*/README.md
+          # rebase on top of any commits that landed while this workflow was running,
+          # so the push won't be rejected with "fetch first".
+          git pull --rebase --autostash origin main
           git push origin main
         else
           echo "No change on lib"
         fi
-    - name: Commit 
+    - name: Commit
       run: |
         if [ $(git diff | wc -l) != 0 ]; then
           git commit -m "format" .
+          git pull --rebase --autostash origin main
           git push origin main
         else
           echo "No change format"


### PR DESCRIPTION
## Summary

Follow-up to making the **Update Build** workflow actually succeed on main.

The original failure (https://github.com/receptron/graphai/actions/runs/27117048349/job/80025991827) was \`GH006: Protected branch update failed\` — the workflow's auto-commit step couldn't push to \`main\` because the GitHub Actions bot wasn't in the branch protection bypass list. **That was fixed out-of-band** by adding \`github-actions\` to \`/repos/receptron/graphai/branches/main/protection/restrictions/apps\`.

A re-run then surfaced a **separate** failure:

\`\`\`
! [rejected]        main -> main (fetch first)
hint: Updates were rejected because the remote contains work that you do not
hint: have locally.
\`\`\`

This is a race: between \`actions/checkout\` and \`git push\`, another commit can land on main (typical when the workflow takes a minute or two and a human / dependabot pushes in the meantime). The plain \`git push origin main\` then fails.

## Fix

Run \`git pull --rebase --autostash origin main\` immediately before each push. The auto-generated commit (\`Update lib or docs\` / \`format\`) gets rebased on top of whatever the latest main is at push time, so the push always fast-forwards.

\`--autostash\` is defensive in case any later step left unstaged changes around.

Also dropped two trailing spaces from \`- name: Commit \` lines.

## Items to Confirm / Review

1. The new \`git pull --rebase\` re-fetches \`origin\` mid-job; since the workflow runs with \`GITHUB_TOKEN\` permissions \`contents: write\`, this should work without extra config. Flag if your branch protection is stricter than the default.
2. If two of these Update Build workflows ever race **with each other** (unlikely given the trigger is \`push to main\` and serialised), the rebase will still resolve cleanly because both produce only auto-generated files at known paths and the second one will see no diff and skip.
3. This PR does **not** change the original behaviour when main hasn't moved — \`git pull --rebase\` is a no-op then.

## Test plan

- [ ] CI on this PR is green.
- [ ] After merge, the next push to main should kick off Update Build and complete without a push rejection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build workflow to include rebase steps when committing changes to ensure conflicts are handled properly during automated updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->